### PR TITLE
fix: Handle tab selection change to correctly show `Sign up` or `Login` button

### DIFF
--- a/app/exerlog/lib/UI/login_screen/login_page.dart
+++ b/app/exerlog/lib/UI/login_screen/login_page.dart
@@ -46,6 +46,7 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
     super.initState();
 
     controller = TabController(length: tabs.length, vsync: this);
+    controller.addListener(_handleTabSelection);
   }
 
   @override
@@ -162,6 +163,12 @@ class _LoginPageState extends State<LoginPage> with SingleTickerProviderStateMix
         ),
       ),
     );
+  }
+
+  void _handleTabSelection() {
+    setState(() {
+      index = controller.index;
+    });
   }
 }
 


### PR DESCRIPTION
fix(#20): Handle tab selection change and update the `index` value. The `Sign up` button is displayed now when the `Sign up` tab is selected.