### PR TITLE
Fix Typo And Change "It's" to Possessive "Its" And Remove Redundancy In Link URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/img/logo-dark.png?raw=true?raw=true#gh-light-mode-only">
+<img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/img/logo-dark.png?raw=true#gh-light-mode-only">
 <img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/img/logo-light.png?raw=true#gh-dark-mode-only">
 </p>
 
@@ -11,7 +11,7 @@ ExerLog is a simple and easy-to-use exercise journal app developed in conjunctio
 
 Create workouts and keep track of your reps, sets, weight, total weight, total reps, total sets, maxes and more. Track important physical measurements including bodyweight, waist size, arm size, and more. Then, visualize all of these measurements in bar charts and graphs that show your advancement over time. 
 
-Right now the project is in it's infancy so there are a lot of features left to be added. If you want to follow the full buildout of this project then I (Kalle Hallden) have a YouTube channel where I document the progress every week: https://youtube.com/playlist?list=PL5tVJtjoxKzpxnc9ventef-1sgvoR8nqG
+Right now the project is in its infancy so there are a lot of features left to be added. If you want to follow the full buildout of this project then I (Kalle Hallden) have a YouTube channel where I document the progress every week: https://youtube.com/playlist?list=PL5tVJtjoxKzpxnc9ventef-1sgvoR8nqG
 
 ## Technologies used
 


### PR DESCRIPTION
Basically what it says in the title.

`Right now the project is in **it's** infancy so there are a lot of features left to be added.`

becomes:

`Right now the project is in **its** infancy so there are a lot of features left to be added.`

and 

`<img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/img/logo-dark.png?raw=true?raw=true#gh-light-mode-only">`

becomes:

`<img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/img/logo-dark.png?raw=true#gh-light-mode-only">`
