### PR TITLE
CONTRIBUTING.md rename & README.md file spelling fixes

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,43 +1,44 @@
-Contributing
+# Contributing
 
 When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 Pull Request Process
-    
+
     1. Find yourself an issue you want to work on, see if anybody is working on it, if not, then assign it to yourself
     2. Fork the repo, create a branch for your issue
     3. Make changes, commit and open a pull request into the [alpha](https://github.com/KalleHallden/exer_log/tree/alpha) branch
     4. Request review from a contributor
-    5. If your pr was approved, rebase and squash your commits, then merge it. 
-    6. Good job, you've just contributed! 
-    
-    Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations and container parameters.
-    You may merge your pull request after receving an approval from Kalle, or any other core contributor.
+    5. If your pr was approved, rebase and squash your commits, then merge it.
+    6. Good job, you've just contributed!
 
-Code of Conduct
-Our Pledge
+    Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations and container parameters.
+    You may merge your pull request after receiving an approval from Kalle, or any other core contributor.
+
+## Code of Conduct
+
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
-    Using welcoming and inclusive language
-    Being respectful of differing viewpoints and experiences
-    Gracefully accepting constructive criticism
-    Focusing on what is best for the community
-    Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-    The use of sexualized language or imagery and unwelcome sexual attention or advances
-    Trolling, insulting/derogatory comments, and personal or political attacks
-    Public or private harassment
-    Publishing others' private information, such as a physical or electronic address, without explicit permission
-    Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
-Our Responsibilities
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Workout metrics:
 ## Future features
 Workout analytics:
 - Charts for strength increases over time
-- Charts for volume (ie total weight and average weight per workout) over time (for easy periodisation)
+- Charts for volume (ie total weight and average weight per workout) over time (for easy periodization)
 - Progressive overload tracking
 
 Workout Planner:
@@ -50,7 +50,7 @@ Body metrics:
 
 Contributions are always welcome!
 
-See [CONTRIBUTING.md](https://github.com/KalleHallden/exer_log/blob/master/CONTRIBUTING.md) for ways to get started.
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for ways to get started.
 
 Please adhere to this project's `code of conduct`.
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -323,7 +323,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   logger:
     dependency: "direct main"
     description:
@@ -344,7 +344,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -517,7 +517,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -559,7 +559,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -573,7 +573,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
@@ -603,5 +603,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.10.0-0"


### PR DESCRIPTION
1. GitHub can not detect the `CONTRIBUTING.md` file, therefore I change it to `CODE_OF_CONDUCT.md`

![Screen Shot 2022-08-17 at 6 37 53 AM](https://user-images.githubusercontent.com/21225918/185009399-50bb2d9f-3c8d-4f24-ad93-22dd0ab4bfd7.png)

2. Spelling fix in `README.md`