### PR TITLE
Fix the All Contributors badge in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <p align="center">
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+  
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+ 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/logo-dark.png?raw=true#gh-light-mode-only">
 <img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/logo-light.png?raw=true#gh-dark-mode-only">


### PR DESCRIPTION
Add some space between 
``` 
[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
```
and the Start and End of the badge, because now all you can see is line of code
```
[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
```
 instead of the Badge 

im sorry i didn't see that there was already a pull requests about this in #81 