### PR TITLE
Fixing the color issue in ```onNetworkConnectionError.dart```

### DIFF
--- a/lib/UI/calendar/view/calendar_page.dart
+++ b/lib/UI/calendar/view/calendar_page.dart
@@ -1,13 +1,13 @@
 import 'package:exerlog/UI/calendar/widgets/calendar_widget.dart';
 import 'package:exerlog/UI/calendar/widgets/logout_button.dart';
 import 'package:exerlog/UI/global.dart';
+import 'package:exerlog/src/widgets/SnackBars/noNetworkConnectionSnackBar.dart';
 import 'package:exerlog/src/widgets/gradient_button.dart';
 import 'package:exerlog/UI/workout/workout_page.dart';
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:connectivity/connectivity.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 
-import '../../../src/widgets/SnackBars/noNetworkConnectionSnackBar.dart';
 
 class CalendarPage extends StatefulWidget {
   @override

--- a/lib/src/widgets/SnackBars/noNetworkConnectionSnackBar.dart
+++ b/lib/src/widgets/SnackBars/noNetworkConnectionSnackBar.dart
@@ -1,14 +1,15 @@
 import 'package:exerlog/UI/global.dart';
+import 'package:exerlog/src/core/theme/theme_color.dart';
 import 'package:flutter/material.dart';
 
 SnackBar noNetworkConnectionSnackBar() => SnackBar(
-      backgroundColor: redBackgroundColor,
+      backgroundColor: ThemeColor.red,
       duration: Duration(
           days:
               365), // set to a year so that it doesn't disappear automatically untill the user clicks on the Dismiss button
       content: Text('No network connection, please check your connection'),
       action: SnackBarAction(
-        textColor: textColorBlue,
+        textColor: ThemeColor.darkBlue,
         label: 'Dismiss',
         onPressed: () {},
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,34 +71,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
-  connectivity:
+  connectivity_plus:
     dependency: "direct main"
     description:
-      name: connectivity
+      name: connectivity_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
-  connectivity_for_web:
+    version: "2.3.6+1"
+  connectivity_plus_linux:
     dependency: transitive
     description:
-      name: connectivity_for_web
+      name: connectivity_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0+1"
-  connectivity_macos:
+    version: "1.3.1"
+  connectivity_plus_macos:
     dependency: transitive
     description:
-      name: connectivity_macos
+      name: connectivity_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+2"
-  connectivity_platform_interface:
+    version: "1.2.4"
+  connectivity_plus_platform_interface:
     dependency: transitive
     description:
-      name: connectivity_platform_interface
+      name: connectivity_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.2.1"
+  connectivity_plus_web:
+    dependency: transitive
+    description:
+      name: connectivity_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.3"
+  connectivity_plus_windows:
+    dependency: transitive
+    description:
+      name: connectivity_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.2"
   crypto:
     dependency: transitive
     description:
@@ -113,6 +127,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.3"
   dropdown_search:
     dependency: "direct main"
     description:
@@ -373,6 +394,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,8 @@ dependencies:
   flutter_riverpod: ^1.0.0
   logger: ^1.1.0
   shared_preferences: ^2.0.15
-  connectivity: ^3.0.6
+  connectivity_plus: ^2.3.6+1
+  
 
 flutter_icons:
   android: true


### PR DESCRIPTION
Fixing the color that simply a mistake i made by not setting values to `redBackgroundColor` and `textColorBlue` 

and also using ```connectivity_plus``` instead of ```connectivity``` because this package does support sound null safety

<h3>why did this happend ?</h3>
 i looked into the pull requests that got merged @jorre127 when he did this [PR](https://github.com/KalleHallden/exer_log/pull/94) he accidently removed the colors from the global.dart file and his PR was merged after my PR was merged, and that cause to  `redBackgroundColor` and `textColorBlue` not being found

so it will be nice to have somone look through PR's and make sure they don't delet or remove a piece of code that well be used in an other PR