### PR TITLE
Fixing the all-contributorsrc error

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -62,7 +62,7 @@
       ]
     }
   ],
-  "badgeTemplate": "<a href="#contributors" alt="Contributors"><img src="https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square" /></a>",
+  "badgeTemplate": "<a href="#contributors" alt="Contributors"><img src="https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square" />/a>",
   "contributorsPerLine": 7,
   "projectName": "exer_log",
   "projectOwner": "KalleHallden",


### PR DESCRIPTION
When trying to use the all contributors bot [this](https://github.com/KalleHallden/exer_log/pull/111) error came up. I tried to look through the [all-contributorsrc](https://github.com/KalleHallden/exer_log/blob/alpha/.all-contributorsrc) but couldn't really see anything except potentially one too any '<' so I removed it. Not sure if this is what the problem was though.