### PR TITLE
chore: fix logo URL to use relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <!-- Logo -->
 <p align="center">
-  <img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/logo-dark.png?raw=true#gh-light-mode-only">
-  <img width="300" src="https://github.com/KalleHallden/exer_log/blob/master/assets/logo-light.png?raw=true#gh-dark-mode-only">
+  <img width="300" src="/assets/logo-dark.png?raw=true#gh-light-mode-only">
+  <img width="300" src="/assets/logo-light.png?raw=true#gh-dark-mode-only">
 </p>
 
 ---


### PR DESCRIPTION
I noticed the logo does not work in GitHub Mobile so I checked and found out the issue was it is using absolute links. The problem with absolute links can be broken if the reference branch is missing. The solution is quite simple, we just need to use relative links.