### PR TITLE
chore: update configuration for `mergeable`

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -19,20 +19,6 @@ defaults:
 
 version: 2
 mergeable:
-  - when: pull_request.opened
-    name: "When pull_request.opened"
-    validate: []
-    pass:
-      - do: assign
-        assignees: [ '@author' ]
-      - do: request_review
-        reviewers: [ 'KalleHallden' ]
-  - when: issues.opened
-    name: "When issues.opened"
-    validate: []
-    pass:
-      - do: assign
-        assignees: [ 'KalleHallden' ]
   - when: pull_request.*, pull_request_review.*
     name: 'Validate Pull Request Description'
     validate:
@@ -87,5 +73,8 @@ mergeable:
         min:
           count: 1
         and:
-          - required:
-              reviewers: [ 'KalleHallden' ]
+          - block:
+            changes_requested: true
+          - limit:
+              reviewers: [ 'EXERLOG/maintainers' ]
+              owners: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,5 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-*   @KalleHallden
+*                          @EXERLOG/maintainers
+.github/mergeable.yml      @tenshiAMD


### PR DESCRIPTION
This is to update the configuration for `mergeable` which we have some reviewer changes in the approval check.