### PR TITLE
chore: update configuration for `mergeable`

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -25,14 +25,6 @@ mergeable:
     pass:
       - do: assign
         assignees: [ '@author' ]
-      - do: request_review
-        reviewers: [ 'KalleHallden' ]
-  - when: issues.opened
-    name: "When issues.opened"
-    validate: []
-    pass:
-      - do: assign
-        assignees: [ 'KalleHallden' ]
   - when: pull_request.*, pull_request_review.*
     name: 'Validate Pull Request Description'
     validate:
@@ -88,4 +80,10 @@ mergeable:
           count: 1
         and:
           - required:
-              reviewers: [ 'KalleHallden' ]
+            reviewers: [ 'KalleHallden' ]
+          - required:
+            reviewers: [ 'tenshiAMD' ]
+          - required:
+            reviewers: [ 'jorre127' ]
+          - required:
+            reviewers: [ 'dinurymomshad' ]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,5 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-*   @KalleHallden
+*                          @EXERLOG/maintainers
+.github/mergeable.yml      @tenshiAMD


### PR DESCRIPTION
This is to update the configuration for `mergeable` which we have some reviewer changes in the approval check.