### PR TITLE
chore: fix incorrect indention in `mergeable`

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -80,10 +80,10 @@ mergeable:
           count: 1
         and:
           - required:
-            reviewers: [ 'KalleHallden' ]
+              reviewers: [ 'KalleHallden' ]
           - required:
-            reviewers: [ 'tenshiAMD' ]
+              reviewers: [ 'tenshiAMD' ]
           - required:
-            reviewers: [ 'jorre127' ]
+              reviewers: [ 'jorre127' ]
           - required:
-            reviewers: [ 'dinurymomshad' ]
+              reviewers: [ 'dinurymomshad' ]


### PR DESCRIPTION
This is to fix incorrect indention in `mergeable`.