### PR TITLE
fix: Widget overflow resolved by using flexible widgets

### DIFF
--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -149,48 +149,44 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              Container(
-                                width: screenWidth * 0.08,
-                              ),
-                              Container(
+                              Spacer(flex: 8),
+                              Expanded(
                                 child: Center(
                                   child: Text(
                                     "Reps",
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
+                                flex: 15,
                               ),
-                              Container(
+                              Expanded(
                                 child: Center(
                                   child: Text(
                                     "Sets",
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
+                                flex: 15,
                               ),
-                              Container(
+                              Expanded(
                                 child: Center(
                                   child: Text(
                                     "Weight",
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
+                                flex: 15,
                               ),
-                              Container(
+                              Expanded(
                                 child: Center(
                                   child: Text(
                                     "Rest",
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
+                                flex: 15,
                               ),
-                              Container(
-                                width: screenWidth * 0.1,
-                              ),
+                              Spacer(flex: 10)
                             ],
                           ),
                         ),

--- a/lib/UI/exercise/set_widget.dart
+++ b/lib/UI/exercise/set_widget.dart
@@ -94,38 +94,38 @@ class _SetWidgetState extends State<SetWidget>
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Container(
+              Expanded(
                 child: Center(
                     child: Text(
                   "#" + (widget.id + 1).toString(),
                   style: setStyle,
                 )),
-                width: screenWidth * 0.08,
+                flex: 8,
               ),
-              Container(
+              Expanded(
                 child: getTextField(0),
-                width: screenWidth * 0.145,
+                flex: 15,
               ),
-              Container(
+              Expanded(
                 child: getTextField(1),
-                width: screenWidth * 0.145,
+                flex: 15,
               ),
-              Container(
+              Expanded(
                 child: getTextField(2),
-                width: screenWidth * 0.145,
+                flex: 15,
               ),
-              Container(
+              Expanded(
                 child: getTextField(3),
-                width: screenWidth * 0.145,
+                flex: 15,
               ),
-              Container(
+              Expanded(
                 child: ValueListenableBuilder(
                 valueListenable: _notifier,
                 builder: (BuildContext context, SetData value, Widget? child) {
                   return MaxInformation(id: widget.exercise.name, sets: widget.exercise.sets[widget.id], setMax: setOneRepMax, setPercentage: setPercentage);
                 } 
               ), 
-                width: screenWidth * 0.11,
+                flex: 10,
               ),
             ],
           ),


### PR DESCRIPTION
### Issue

The Exercise Card widget size is defined relative to the screen size of the device. Its child widgets are also defined relative to the screen size. The width taken up by the child widgets is greater than the space made available from the parent widget. This results in widget overflow as seen in the below image.

![SmartSelect_20220824-220405](https://user-images.githubusercontent.com/60143172/186526800-c40da493-6c21-431a-9eb2-984159c5db93.jpg)

### Solution

By making use of flexible widgets such as "Expanded" and "Spacer" we can access the "flex" property and define the child widget sizes by reference to their immediate parent. This will prevent widget overflow.

![SmartSelect_20220824-222016](https://user-images.githubusercontent.com/60143172/186527676-3ecef36f-d067-408f-a4af-3f945182b6a7.jpg)

I kept the same ratios in the Exercise Card widget the same as before, but made slight changes to the ratios in the Set Widget to align it with the Exercise Card widget. 

When defining the size of a widget that is the child of another sized widget, we should make use of flexible widgets as best practice. This will prevent similar UI issues in the future.