### PR TITLE
fix: divide by 0 error when oneRepMax 0.0

### DIFF
--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -68,7 +68,7 @@ class _MaxInformationState extends State<MaxInformation> {
 
   String oneRepMaxPercentLabel(double weight, double oneRepMax) {
     if (oneRepMax > 0.0) {
-      text = ((weight / oneRepMax) * 100).round().toString() + "%";
+      this.text = ((weight / oneRepMax) * 100).round().toString() + "%";
     }
 
     return this.text;

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -6,17 +6,18 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class MaxInformation extends StatefulWidget {
-  final String id;
-  Sets sets;
-  Function? setMax;
-  Function? setPercentage;
-
   MaxInformation({
     required this.id,
     required this.sets,
     this.setMax,
     this.setPercentage,
   });
+
+  final String id;
+  Sets sets;
+  Function? setMax;
+  Function? setPercentage;
+
   @override
   _MaxInformationState createState() => _MaxInformationState();
 }
@@ -24,6 +25,7 @@ class MaxInformation extends StatefulWidget {
 class _MaxInformationState extends State<MaxInformation> {
   double oneRepMax = 0.0;
   String text = "0%";
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<Max>(

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -1,9 +1,6 @@
-import 'package:exerlog/Bloc/exercise_bloc.dart';
 import 'package:exerlog/Bloc/max_bloc.dart';
-import 'package:exerlog/Models/exercise.dart';
 import 'package:exerlog/Models/maxes.dart';
 import 'package:exerlog/Models/sets.dart';
-import 'package:exerlog/Models/workout.dart';
 import 'package:exerlog/UI/global.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -43,7 +40,7 @@ class _MaxInformationState extends State<MaxInformation> {
             return Center(
               child: Text(text, style: setStyle,),
             );
-          } else { 
+          } else {
             oneRepMax = snapshot.data!.weight / maxTable[snapshot.data!.reps -1];
             if (snapshot.data!.weight == 0.0) {
               print("No max");
@@ -52,7 +49,11 @@ class _MaxInformationState extends State<MaxInformation> {
               widget.setMax!(snapshot.data);
               widget.setPercentage!(widget.sets.weight / oneRepMax);
             }
-            text = ((widget.sets.weight / oneRepMax) * 100).round().toString() + "%";
+
+            if (oneRepMax > 0.0){
+              text = ((widget.sets.weight / oneRepMax) * 100).round().toString() + "%";
+            }
+
             return Center(
               child: Text(text, style: setStyle,),
             );

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -11,8 +11,12 @@ class MaxInformation extends StatefulWidget {
   Function? setMax;
   Function? setPercentage;
 
-  MaxInformation(
-      {required this.id, required this.sets, this.setMax, this.setPercentage});
+  MaxInformation({
+    required this.id,
+    required this.sets,
+    this.setMax,
+    this.setPercentage,
+  });
   @override
   _MaxInformationState createState() => _MaxInformationState();
 }
@@ -25,21 +29,22 @@ class _MaxInformationState extends State<MaxInformation> {
     return FutureBuilder<Max>(
       future: getOneRepMax(widget.id),
       builder: (BuildContext context, AsyncSnapshot<Max> snapshot) {
+        Sets sets = widget.sets;
         if (snapshot.connectionState == ConnectionState.waiting) {
           return Center(
             child: CircularProgressIndicator(),
           );
         } else {
           if (snapshot.hasError) {
-            if (minimumOneWeightRep(widget.sets)) {
-              oneRepMax = widget.sets.weight / maxTable[widget.sets.reps - 1];
+            if (minimumOneWeightRep(sets)) {
+              oneRepMax = sets.weight / maxTable[sets.reps - 1];
               widget.setMax!(Max(oneRepMax, 1, 0, widget.id));
-              widget.setPercentage!(widget.sets.weight / oneRepMax);
+              widget.setPercentage!(sets.weight / oneRepMax);
             }
 
             return Center(
               child: Text(
-                oneRepMaxPercentLabel(widget.sets.weight, oneRepMax),
+                oneRepMaxPercentLabel(sets.weight, oneRepMax),
                 style: setStyle,
               ),
             );
@@ -51,12 +56,12 @@ class _MaxInformationState extends State<MaxInformation> {
             }
             if (widget.setMax != null) {
               widget.setMax!(snapshot.data);
-              widget.setPercentage!(widget.sets.weight / oneRepMax);
+              widget.setPercentage!(sets.weight / oneRepMax);
             }
 
             return Center(
               child: Text(
-                oneRepMaxPercentLabel(widget.sets.weight, oneRepMax),
+                oneRepMaxPercentLabel(sets.weight, oneRepMax),
                 style: setStyle,
               ),
             );

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -31,19 +31,15 @@ class _MaxInformationState extends State<MaxInformation> {
           );
         } else {
           if (snapshot.hasError) {
-            if (widget.sets.weight != 0.0 &&
-                widget.sets.reps < 30 &&
-                widget.sets.reps > 0) {
+            if (minimumOneWeightRep(widget.sets)) {
               oneRepMax = widget.sets.weight / maxTable[widget.sets.reps - 1];
               widget.setMax!(Max(oneRepMax, 1, 0, widget.id));
               widget.setPercentage!(widget.sets.weight / oneRepMax);
-              text =
-                  ((widget.sets.weight / oneRepMax) * 100).round().toString() +
-                      "%";
             }
+
             return Center(
               child: Text(
-                text,
+                oneRepMaxPercentLabel(widget.sets.weight, oneRepMax),
                 style: setStyle,
               ),
             );
@@ -58,15 +54,9 @@ class _MaxInformationState extends State<MaxInformation> {
               widget.setPercentage!(widget.sets.weight / oneRepMax);
             }
 
-            if (oneRepMax > 0.0) {
-              text =
-                  ((widget.sets.weight / oneRepMax) * 100).round().toString() +
-                      "%";
-            }
-
             return Center(
               child: Text(
-                text,
+                oneRepMaxPercentLabel(widget.sets.weight, oneRepMax),
                 style: setStyle,
               ),
             );
@@ -74,5 +64,17 @@ class _MaxInformationState extends State<MaxInformation> {
         }
       },
     );
+  }
+
+  String oneRepMaxPercentLabel(double weight, double oneRepMax) {
+    if (oneRepMax > 0.0) {
+      text = ((weight / oneRepMax) * 100).round().toString() + "%";
+    }
+
+    return this.text;
+  }
+
+  bool minimumOneWeightRep(Sets sets) {
+    return sets.weight != 0.0 && sets.reps < 30 && sets.reps > 0;
   }
 }

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -11,10 +11,10 @@ class MaxInformation extends StatefulWidget {
   Function? setMax;
   Function? setPercentage;
 
-  MaxInformation({required this.id, required this.sets, this.setMax, this.setPercentage});
+  MaxInformation(
+      {required this.id, required this.sets, this.setMax, this.setPercentage});
   @override
   _MaxInformationState createState() => _MaxInformationState();
-
 }
 
 class _MaxInformationState extends State<MaxInformation> {
@@ -31,17 +31,25 @@ class _MaxInformationState extends State<MaxInformation> {
           );
         } else {
           if (snapshot.hasError) {
-            if (widget.sets.weight != 0.0 && widget.sets.reps < 30 && widget.sets.reps > 0) {
+            if (widget.sets.weight != 0.0 &&
+                widget.sets.reps < 30 &&
+                widget.sets.reps > 0) {
               oneRepMax = widget.sets.weight / maxTable[widget.sets.reps - 1];
               widget.setMax!(Max(oneRepMax, 1, 0, widget.id));
               widget.setPercentage!(widget.sets.weight / oneRepMax);
-              text = ((widget.sets.weight / oneRepMax) * 100).round().toString() + "%";
+              text =
+                  ((widget.sets.weight / oneRepMax) * 100).round().toString() +
+                      "%";
             }
             return Center(
-              child: Text(text, style: setStyle,),
+              child: Text(
+                text,
+                style: setStyle,
+              ),
             );
           } else {
-            oneRepMax = snapshot.data!.weight / maxTable[snapshot.data!.reps -1];
+            oneRepMax =
+                snapshot.data!.weight / maxTable[snapshot.data!.reps - 1];
             if (snapshot.data!.weight == 0.0) {
               print("No max");
             }
@@ -50,17 +58,21 @@ class _MaxInformationState extends State<MaxInformation> {
               widget.setPercentage!(widget.sets.weight / oneRepMax);
             }
 
-            if (oneRepMax > 0.0){
-              text = ((widget.sets.weight / oneRepMax) * 100).round().toString() + "%";
+            if (oneRepMax > 0.0) {
+              text =
+                  ((widget.sets.weight / oneRepMax) * 100).round().toString() +
+                      "%";
             }
 
             return Center(
-              child: Text(text, style: setStyle,),
+              child: Text(
+                text,
+                style: setStyle,
+              ),
             );
           }
         }
       },
     );
   }
-
 }


### PR DESCRIPTION
before:

![excersise-max-error](https://user-images.githubusercontent.com/57678185/186649834-f2c54e33-c4cc-4b6e-b015-9f2d483e9a1a.png)

after fix:

![excersise-max-error-fixed](https://user-images.githubusercontent.com/57678185/186649893-96745ded-405f-4ee8-a20c-eb2f9f14a36d.png)

problem was in creating text label as a result of divide something by 0:

```
text = ((widget.sets.weight / oneRepMax) * 100).round().toString() + "%";
```