### PR TITLE
chore: fix reviewers in `mergeable` approval check

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -78,7 +78,7 @@ mergeable:
       - do: approvals
         min:
           count: 1
-        and:
+        or:
           - required:
               reviewers: [ 'KalleHallden' ]
           - required:


### PR DESCRIPTION
This is to fix reviewers in `mergeable` approval check.