### PR TITLE
fix: custom FloatingActionButton

### DIFF
--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -4,6 +4,7 @@ import 'package:exerlog/Models/workout_data.dart';
 import 'package:exerlog/UI/exercise/set_widget.dart';
 import 'package:exerlog/UI/exercise/totals_widget.dart';
 import 'package:exerlog/UI/global.dart';
+import 'package:exerlog/src/widgets/custom_floating_action_button.dart';
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
@@ -213,20 +214,13 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                           ],
                         ),
                         borderRadius: BorderRadius.circular(30)),
-                    child: FloatingActionButton(
-                      heroTag: null,
-                      elevation: 0,
-                      backgroundColor: Colors.transparent,
-                      child: Icon(
-                        Icons.add,
-                        size: 50,
-                        color: theme.colorTheme.backgroundColorVariation,
+                    child: CustomFloatingActionButton(
+                        icon: Icons.add,
+                        // addSet
                       ),
-                      onPressed: addSet,
-                    ),
                   ),
                 ),
-              )
+              ),
             ],
           ),
         );

--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -216,7 +216,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                         borderRadius: BorderRadius.circular(30)),
                     child: CustomFloatingActionButton(
                         icon: Icons.add,
-                        // addSet
+                        onTap: addSet,
                       ),
                   ),
                 ),

--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -83,8 +83,10 @@ class _WorkoutPageState extends State<WorkoutPage> {
           backgroundColor: theme.colorTheme.backgroundColorVariation,
           floatingActionButton: CustomFloatingActionButton(
                         icon: Icons.add,
-                        // showAlertDialogExercise(context);
-                      ),
+                        onTap: () {
+                          showAlertDialogExercise(context);
+                        },
+                    ),
           resizeToAvoidBottomInset: true,
           appBar: AppBar(
             backgroundColor: theme.colorTheme.backgroundColorVariation,
@@ -99,22 +101,22 @@ class _WorkoutPageState extends State<WorkoutPage> {
                 width: 30,
                 child: CustomFloatingActionButton(
                   icon: Icons.done,
+                  onTap: () {
+                    for (Exercise exercise in workoutData.workout.exercises) {
+                      for (int i = 0; i < exercise.sets.length; i++) {
+                        if (exercise.sets[i].reps == 0) {
+                          exercise.sets.remove(exercise.sets[i]);
+                        }
+                      }
+                      if (exercise.sets.length == 0) {
+                        workoutData.workout.exercises.remove(exercise);
+                      }
+                    }
+                    if (workoutData.workout.exercises.length > 0) {
+                      showSaveWorkoutAlertDialog(context);
+                    }
+                  },
                 ), 
-                  // onPressed: () {
-                  //   for (Exercise exercise in workoutData.workout.exercises) {
-                  //     for (int i = 0; i < exercise.sets.length; i++) {
-                  //       if (exercise.sets[i].reps == 0) {
-                  //         exercise.sets.remove(exercise.sets[i]);
-                  //       }
-                  //     }
-                  //     if (exercise.sets.length == 0) {
-                  //       workoutData.workout.exercises.remove(exercise);
-                  //     }
-                  //   }
-                  //   if (workoutData.workout.exercises.length > 0) {
-                  //     showSaveWorkoutAlertDialog(context);
-                  //   }
-                  // },
               ),
             ],
           ),

--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -82,11 +82,9 @@ class _WorkoutPageState extends State<WorkoutPage> {
         return Scaffold(
           backgroundColor: theme.colorTheme.backgroundColorVariation,
           floatingActionButton: CustomFloatingActionButton(
-                        icon: Icons.add,
-                        onTap: () {
-                          showAlertDialogExercise(context);
-                        },
-                    ),
+            icon: Icons.add,
+            onTap: () => showAlertDialogExercise(context),
+          ),
           resizeToAvoidBottomInset: true,
           appBar: AppBar(
             backgroundColor: theme.colorTheme.backgroundColorVariation,
@@ -116,7 +114,7 @@ class _WorkoutPageState extends State<WorkoutPage> {
                       showSaveWorkoutAlertDialog(context);
                     }
                   },
-                ), 
+                ),
               ),
             ],
           ),

--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -10,6 +10,7 @@ import 'package:exerlog/UI/workout/save_workout_dialog.dart';
 import 'package:exerlog/UI/workout/workout_name_selection_widget.dart';
 import 'package:exerlog/UI/workout/workout_toatals_widget.dart';
 import 'package:exerlog/src/core/theme/app_theme.dart';
+import 'package:exerlog/src/widgets/custom_floating_action_button.dart';
 import 'package:exerlog/src/widgets/gradient_button.dart';
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
@@ -80,16 +81,10 @@ class _WorkoutPageState extends State<WorkoutPage> {
         workoutTotalsWidget = WorkoutTotalsWidget(totals: workoutData.totals);
         return Scaffold(
           backgroundColor: theme.colorTheme.backgroundColorVariation,
-          floatingActionButton: FloatingActionButton(
-            backgroundColor: theme.colorTheme.primaryColor,
-            child: Icon(
-              Icons.add,
-              color: theme.colorTheme.backgroundColorVariation,
-            ),
-            onPressed: () {
-              showAlertDialogExercise(context);
-            },
-          ),
+          floatingActionButton: CustomFloatingActionButton(
+                        icon: Icons.add,
+                        // showAlertDialogExercise(context);
+                      ),
           resizeToAvoidBottomInset: true,
           appBar: AppBar(
             backgroundColor: theme.colorTheme.backgroundColorVariation,
@@ -102,28 +97,24 @@ class _WorkoutPageState extends State<WorkoutPage> {
                 margin: EdgeInsets.only(right: 5),
                 height: 30,
                 width: 30,
-                child: FloatingActionButton(
-                  backgroundColor: theme.colorTheme.primaryColor,
-                  onPressed: () {
-                    for (Exercise exercise in workoutData.workout.exercises) {
-                      for (int i = 0; i < exercise.sets.length; i++) {
-                        if (exercise.sets[i].reps == 0) {
-                          exercise.sets.remove(exercise.sets[i]);
-                        }
-                      }
-                      if (exercise.sets.length == 0) {
-                        workoutData.workout.exercises.remove(exercise);
-                      }
-                    }
-                    if (workoutData.workout.exercises.length > 0) {
-                      showSaveWorkoutAlertDialog(context);
-                    }
-                  },
-                  child: Icon(
-                    Icons.done,
-                    color: theme.colorTheme.backgroundColorVariation,
-                  ),
-                ),
+                child: CustomFloatingActionButton(
+                  icon: Icons.done,
+                ), 
+                  // onPressed: () {
+                  //   for (Exercise exercise in workoutData.workout.exercises) {
+                  //     for (int i = 0; i < exercise.sets.length; i++) {
+                  //       if (exercise.sets[i].reps == 0) {
+                  //         exercise.sets.remove(exercise.sets[i]);
+                  //       }
+                  //     }
+                  //     if (exercise.sets.length == 0) {
+                  //       workoutData.workout.exercises.remove(exercise);
+                  //     }
+                  //   }
+                  //   if (workoutData.workout.exercises.length > 0) {
+                  //     showSaveWorkoutAlertDialog(context);
+                  //   }
+                  // },
               ),
             ],
           ),

--- a/lib/src/feature/calendar/view/calendar_screen.dart
+++ b/lib/src/feature/calendar/view/calendar_screen.dart
@@ -7,7 +7,6 @@ import 'package:exerlog/src/dependency.dart';
 import 'package:exerlog/src/feature/calendar/widgets/calendar_widget.dart';
 import 'package:exerlog/src/feature/calendar/widgets/logout_button.dart';
 import 'package:exerlog/src/utils/text_constants.dart';
-import 'package:exerlog/src/widgets/custom_floating_action_button.dart';
 import 'package:exerlog/src/widgets/gradient_button.dart';
 import 'package:exerlog/src/widgets/snack_bars/no_network_connection_snackbar.dart';
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
@@ -51,7 +50,6 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 CalendarWidget(),
-                CustomFloatingActionButton(),
                 RaisedGradientButton(
                   child: Text(
                     Texts.startNewWorkout.toUpperCase(),

--- a/lib/src/feature/calendar/view/calendar_screen.dart
+++ b/lib/src/feature/calendar/view/calendar_screen.dart
@@ -7,6 +7,7 @@ import 'package:exerlog/src/dependency.dart';
 import 'package:exerlog/src/feature/calendar/widgets/calendar_widget.dart';
 import 'package:exerlog/src/feature/calendar/widgets/logout_button.dart';
 import 'package:exerlog/src/utils/text_constants.dart';
+import 'package:exerlog/src/widgets/custom_floating_action_button.dart';
 import 'package:exerlog/src/widgets/gradient_button.dart';
 import 'package:exerlog/src/widgets/snack_bars/no_network_connection_snackbar.dart';
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
@@ -50,6 +51,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 CalendarWidget(),
+                CustomFloatingActionButton(),
                 RaisedGradientButton(
                   child: Text(
                     Texts.startNewWorkout.toUpperCase(),

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -1,15 +1,15 @@
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
-// @todo: noch Funktion hinzufügen
-
 class CustomFloatingActionButton extends StatelessWidget {
   final IconData? icon;
   final double? size;
+  final VoidCallback? onTap;
 
   CustomFloatingActionButton({
-    this.icon,
+    @required this.icon,
     this.size = 50.0,
+    @required this.onTap,
   });
 
   @override
@@ -30,7 +30,7 @@ class CustomFloatingActionButton extends StatelessWidget {
           child: Material(
             color: Colors.transparent,
             child: InkWell(
-              onTap: () => {},
+              onTap: onTap,
               borderRadius: BorderRadius.circular(size!),
               child: Container(
                 width: size,

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -1,13 +1,15 @@
 import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
+// @todo: noch Funktion hinzufügen
+
 class CustomFloatingActionButton extends StatelessWidget {
   final IconData? icon;
   final double? size;
 
   CustomFloatingActionButton({
     this.icon,
-    this.size = 40.0,
+    this.size = 50.0,
   });
 
   @override
@@ -37,7 +39,7 @@ class CustomFloatingActionButton extends StatelessWidget {
                   child: Icon(
                     icon,
                     color: theme.colorTheme.backgroundColorVariation,
-                    size: size! * 0.8,
+                    size: size! * 0.4,
                   ),
                 ),
               ),

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -2,14 +2,14 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class CustomFloatingActionButton extends StatelessWidget {
-  final IconData? icon;
-  final double? size;
-  final VoidCallback? onTap;
+  final IconData icon;
+  final VoidCallback onTap;
+  final double size;
 
   CustomFloatingActionButton({
-    @required this.icon,
+    required this.icon,
+    required this.onTap,
     this.size = 50.0,
-    @required this.onTap,
   });
 
   @override
@@ -17,7 +17,7 @@ class CustomFloatingActionButton extends StatelessWidget {
         builder: (context, theme) => Container(
           decoration: BoxDecoration(
             color: theme.colorTheme.primaryColor,
-            borderRadius: BorderRadius.circular(size!),
+            borderRadius: BorderRadius.circular(size),
             boxShadow: [
               BoxShadow(
                 color: theme.colorTheme.shadow,
@@ -31,7 +31,7 @@ class CustomFloatingActionButton extends StatelessWidget {
             color: Colors.transparent,
             child: InkWell(
               onTap: onTap,
-              borderRadius: BorderRadius.circular(size!),
+              borderRadius: BorderRadius.circular(size),
               child: Container(
                 width: size,
                 height: size,
@@ -39,7 +39,7 @@ class CustomFloatingActionButton extends StatelessWidget {
                   child: Icon(
                     icon,
                     color: theme.colorTheme.backgroundColorVariation,
-                    size: size! * 0.4,
+                    size: size * 0.4,
                   ),
                 ),
               ),

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -1,61 +1,44 @@
+import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
-// @todo: write constructors
-// @todo: delete everything from calender_screen.dart
-// @todo: box-shadows -> only sample-one for now
-// @todo: used predefined colors
-
 class CustomFloatingActionButton extends StatelessWidget {
-  const CustomFloatingActionButton(
-      {Color? backgroundColor,
-      Color? iconColor,
-      IconData? icon,
-      double? size,
-      Key? key})
-      : backgroundColor = Colors.black,
-        iconColor = Colors.white,
-        icon = Icons.add,
-        size = 40.0,
-        super(key: key);
-
-  final Color? backgroundColor;
-  final Color? iconColor;
   final IconData? icon;
   final double? size;
 
+  CustomFloatingActionButton({
+    this.icon,
+    this.size = 40.0,
+  });
+
   @override
-  Widget build(BuildContext context) => Container(
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(size!),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black87,
-              blurRadius: 10,
-              spreadRadius: 1,
-              offset: Offset(2, 2),
-            ),
-            BoxShadow(
-              color: Colors.white,
-              blurRadius: 10,
-              spreadRadius: 1,
-              offset: Offset(-2, -2),
-            ),
-          ],
-        ),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: () => {print('tapped')},
+  Widget build(BuildContext context) => ThemeProvider(
+        builder: (context, theme) => Container(
+          decoration: BoxDecoration(
+            color: theme.colorTheme.primaryColor,
             borderRadius: BorderRadius.circular(size!),
-            child: Container(
-              width: size,
-              height: size,
-              child: Center(
-                child: Icon(
-                  icon,
-                  color: iconColor,
-                  size: size! * 0.8,
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorTheme.shadow,
+                blurRadius: 10,
+                spreadRadius: 2,
+                offset: Offset(0, 0),
+              ),
+            ],
+          ),
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () => {},
+              borderRadius: BorderRadius.circular(size!),
+              child: Container(
+                width: size,
+                height: size,
+                child: Center(
+                  child: Icon(
+                    icon,
+                    color: theme.colorTheme.backgroundColorVariation,
+                    size: size! * 0.8,
+                  ),
                 ),
               ),
             ),

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -1,20 +1,65 @@
 import 'package:flutter/material.dart';
 
+// @todo: write constructors
+// @todo: delete everything from calender_screen.dart
+// @todo: box-shadows -> only sample-one for now
+// @todo: used predefined colors
+
 class CustomFloatingActionButton extends StatelessWidget {
   const CustomFloatingActionButton(
-      {Color? backgroundColor, double? size, Key? key})
-      : backgroundColor = Colors.white,
+      {Color? backgroundColor,
+      Color? iconColor,
+      IconData? icon,
+      double? size,
+      Key? key})
+      : backgroundColor = Colors.black,
+        iconColor = Colors.white,
+        icon = Icons.add,
         size = 40.0,
         super(key: key);
 
   final Color? backgroundColor;
+  final Color? iconColor;
+  final IconData? icon;
   final double? size;
 
   @override
   Widget build(BuildContext context) => Container(
-        width: size,
-        height: size,
         decoration: BoxDecoration(
-            color: backgroundColor, borderRadius: BorderRadius.circular(size!)),
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(size!),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black87,
+              blurRadius: 10,
+              spreadRadius: 1,
+              offset: Offset(2, 2),
+            ),
+            BoxShadow(
+              color: Colors.white,
+              blurRadius: 10,
+              spreadRadius: 1,
+              offset: Offset(-2, -2),
+            ),
+          ],
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: () => {print('tapped')},
+            borderRadius: BorderRadius.circular(size!),
+            child: Container(
+              width: size,
+              height: size,
+              child: Center(
+                child: Icon(
+                  icon,
+                  color: iconColor,
+                  size: size! * 0.8,
+                ),
+              ),
+            ),
+          ),
+        ),
       );
 }

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class CustomFloatingActionButton extends StatelessWidget {
+  const CustomFloatingActionButton(
+      {Color? backgroundColor, double? size, Key? key})
+      : backgroundColor = Colors.white,
+        size = 40.0,
+        super(key: key);
+
+  final Color? backgroundColor;
+  final double? size;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+            color: backgroundColor, borderRadius: BorderRadius.circular(size!)),
+      );
+}


### PR DESCRIPTION
# Summary
This PR fixed #132, where the heroTag-property of the FloatingActionButton caused an error. (even if it was set to null)
I created a CustomFloatingActionButton without the heroTag-property and replaced all default FloatingActionButtons.

By now the Class only have 3 members:
* Icon
* size
* Function, when tapped

![floatingActionButtonNormal](https://user-images.githubusercontent.com/78447003/187079345-052a7c30-56a2-4a14-9565-a9265996c0e2.png)
![floatingActionButtonWIthInkwell](https://user-images.githubusercontent.com/78447003/187079346-c726204f-b44e-496b-8f60-459daac022e3.png)