### PR TITLE
fix(ci): require `build_ios` check [ci skip]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       -
         run: flutter build appbundle
   build_ios:
-    continue-on-error: true
+    continue-on-error: false
     runs-on: macos-latest
     steps:
       -


### PR DESCRIPTION
### Summary

This is to require the `build_ios` check.

### Other Information

- None.
