### PR TITLE
refactor: linter code cleanup next part

### DIFF
--- a/lib/Bloc/max_bloc.dart
+++ b/lib/Bloc/max_bloc.dart
@@ -8,7 +8,7 @@ import 'package:exerlog/src/core/base/shared_preference/shared_preference_b.dart
 import 'package:exerlog/src/utils/logger/logger.dart';
 
 Future<List<Max>> getSpecificMax(String exercise, double reps) async {
-  final ref = await FirebaseFirestore.instance
+  final QuerySnapshot<Map<String, dynamic>> ref = await FirebaseFirestore.instance
       .collection('users')
       .doc(SharedPref.getStringAsync(USER_UID))
       .collection('maxes')
@@ -26,9 +26,9 @@ Future<List<Max>> getSpecificMax(String exercise, double reps) async {
 
 void deleteMax(Exercise exercise) async {
   final ref = await firestoreInstance
-      .collection("users")
+      .collection('users')
       .doc(SharedPref.getStringAsync(USER_UID))
-      .collection("maxes")
+      .collection('maxes')
       .where('exerciseID', isEqualTo: exercise.id)
       .get();
   for (int i = 0; i < ref.docs.length; i++) {
@@ -54,10 +54,10 @@ Future<Max> getOneRepMax(String exercise) async {
   Log.info(ref.docs.first.data().toString());
 
   Max returnMax;
-  if (ref.docs.length > 0) {
+  if (ref.docs.isNotEmpty) {
     returnMax = Max.fromJson(ref.docs.first.data());
   } else {
-    returnMax = new Max(0, 0, 0, '');
+    returnMax = Max(0, 0, 0, '');
   }
   return returnMax;
 }
@@ -65,9 +65,9 @@ Future<Max> getOneRepMax(String exercise) async {
 void saveMax(Max max) {
   Map<String, Object?> jsonMax = max.toJson();
   firestoreInstance
-      .collection("users")
+      .collection('users')
       .doc(SharedPref.getStringAsync(USER_UID))
-      .collection("maxes")
+      .collection('maxes')
       .add(jsonMax)
       .then((value) {
   });
@@ -75,18 +75,18 @@ void saveMax(Max max) {
 
 void checkMax(Exercise exercise) async {
   // check if max already exists otherwise save
-  final ref = await FirebaseFirestore.instance
+  final QuerySnapshot<Map<String, dynamic>> ref = await FirebaseFirestore.instance
       .collection('users')
       .doc(SharedPref.getStringAsync(USER_UID))
       .collection('maxes')
       .where('exercise', isEqualTo: exercise.name)
       .get();
 
-  if (ref.docs.length == 0) {
+  if (ref.docs.isEmpty) {
     List setList = [];
     for (Sets set in exercise.sets) {
       // check which ones are maxes and which aren't
-      if (setList.length > 0) {
+      if (setList.isNotEmpty) {
         bool shouldUpdate = true;
         for (Sets newSet in setList) {
           if (newSet.reps == set.reps && newSet.weight == set.weight) {

--- a/lib/Bloc/workout_bloc.dart
+++ b/lib/Bloc/workout_bloc.dart
@@ -105,7 +105,6 @@ void saveWorkout(Workout workout) async {
 }
 
 void deleteWorkout(Workout workout) async {
-
   for (Exercise exercise in workout.exercises) {
     deleteExercise(exercise);
   }

--- a/lib/Models/exercise.dart
+++ b/lib/Models/exercise.dart
@@ -3,6 +3,18 @@ import 'package:exerlog/Models/sets.dart';
 import 'package:exerlog/UI/exercise/totals_widget.dart';
 
 class Exercise {
+
+  Exercise(this.name, this.sets, this.bodyParts, this.totalSets, this.totalReps,
+      this.totalWeight,);
+
+  Exercise.fromJson(Map<String, Object?> exercise)
+      : this.name = exercise['name']! as String,
+        this.sets = exercise['sets']! as List,
+        this.bodyParts = exercise['body_parts']! as List,
+        this.totalReps = exercise['total_reps']! as int,
+        this.totalWeight = exercise['total_weight']! as double,
+        this.totalSets = exercise['total_sets']! as int;
+
   String name;
   List sets;
   List bodyParts;
@@ -10,11 +22,9 @@ class Exercise {
   int totalReps;
   double totalWeight;
   int totalSets;
-  ExerciseTotalsWidget totalWidget = new ExerciseTotalsWidget(
-      totals: new TotalsData(0, 0, 0.0, 0.0), index: 0);
 
-  Exercise(this.name, this.sets, this.bodyParts, this.totalSets, this.totalReps,
-      this.totalWeight);
+  ExerciseTotalsWidget totalWidget =
+      ExerciseTotalsWidget(totals: TotalsData(0, 0, 0.0, 0.0), index: 0);
 
   void setExerciseTotals() {
     totalReps = 0;
@@ -47,12 +57,4 @@ class Exercise {
       'created': FieldValue.serverTimestamp()
     };
   }
-
-  Exercise.fromJson(Map<String, Object?> exercise)
-      : this.name = exercise['name']! as String,
-        this.sets = exercise['sets']! as List,
-        this.bodyParts = exercise['body_parts']! as List,
-        this.totalReps = exercise['total_reps']! as int,
-        this.totalWeight = exercise['total_weight']! as double,
-        this.totalSets = exercise['total_sets']! as int;
 }

--- a/lib/Models/maxes.dart
+++ b/lib/Models/maxes.dart
@@ -1,13 +1,21 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Max {
+
+  Max(this.weight, this.reps, this.sets, this.exercise,);
+
+  Max.fromJson(Map<String, Object?> max)
+      : this.sets = max['sets']! as int,
+        this.reps = max['reps']! as int,
+        this.weight = max['weight']! as double,
+        this.exercise = max['exercise']! as String,
+        this.exerciseID = max['exerciseID']! as String;
+
   int reps;
   int sets;
   double weight;
   String exercise;
   String? exerciseID;
-
-  Max(this.weight, this.reps, this.sets, this.exercise);
 
   Map<String, dynamic> toJson() {
     return {
@@ -19,13 +27,6 @@ class Max {
       'exerciseID': exerciseID
     };
   }
-
-  Max.fromJson(Map<String, Object?> max)
-      : this.sets = max['sets']! as int,
-        this.reps = max['reps']! as int,
-        this.weight = max['weight']! as double,
-        this.exercise = max['exercise']! as String,
-        this.exerciseID = max['exerciseID']! as String;
 }
 
 /*

--- a/lib/Models/prev_workout_data.dart
+++ b/lib/Models/prev_workout_data.dart
@@ -8,23 +8,25 @@ import 'package:exerlog/UI/workout/workout_toatals_widget.dart';
 import 'package:exerlog/src/utils/logger/logger.dart';
 
 class PrevWorkoutData {
-  Function(Workout) updateTotals;
-  Workout workout;
-  WorkoutTotals totals;
-  Function(Exercise, Sets, int) addNewSet;
-  List<PrevExerciseCard> exerciseWidgets = [];
 
   PrevWorkoutData(this.workout, this.totals, this.updateTotals, this.addNewSet) {
+
     workout = this.workout;
 
       loadWorkoutData().then((value) {
         workout = value;
         setExerciseWidgets();
-        for (Exercise exercise in this.workout.exercises) {
+        for (Exercise exercise in workout.exercises) {
           updateExisitingExercise(exercise);
         }
+
       });
   }
+  Function(Workout) updateTotals;
+  Workout workout;
+  WorkoutTotals totals;
+  Function(Exercise, Sets, int) addNewSet;
+  List<PrevExerciseCard> exerciseWidgets = [];
 
   addSet(exercise, newSet, id) {
     exercise.sets[id] = newSet;
@@ -32,33 +34,41 @@ class PrevWorkoutData {
   }
 
   Future<Workout> loadWorkoutData() async {
+
     Workout loadedWorkout =
-        new Workout(workout.exercises, '', '', 0, '', '', true, 0, 0.0, 0);
+        Workout(workout.exercises, '', '', 0, '', '', true, 0, 0.0, 0);
+
     loadedWorkout.id = workout.id;
     List<Exercise> exerciseList = [];
     int totalSets = 0;
     int totalReps = 0;
     double totalKgs = 0;
     int reps = 0;
-    try {
-      for (String exerciseId in workout.exercises) {
-        await loadExercise(exerciseId)
-            .then((value) async => {
-              exerciseList.add(value),
-              for (Sets sets in value.sets)
-                {
-                  totalSets += sets.sets,
-                  reps = sets.reps * sets.sets,
-                  totalReps += reps,
-                  totalKgs += reps * sets.weight,
-                },
-              });
+    List<String> toRemove = [];
+    for (String exerciseId in workout.exercises) {
+      try {
+        await loadExercise(exerciseId).then(
+          (Exercise value) async => {
+            exerciseList.add(value),
+            for (Sets sets in value.sets)
+              {
+                totalSets += sets.sets,
+                reps = sets.reps * sets.sets,
+                totalReps += reps,
+                totalKgs += reps * sets.weight,
+              },
+          },
+        );
+      } catch (exception) {
+        toRemove.add(exerciseId);
+        Log.debug('load workout error:' + exception.toString());
       }
-      loadedWorkout.exercises = exerciseList;
-
-    } catch (exception) {
-      Log.debug(exception.toString());
     }
+
+    workout.exercises.removeWhere((e) => toRemove.contains(e));
+
+    loadedWorkout.exercises = exerciseList;
+
     return loadedWorkout;
   }
 
@@ -68,30 +78,36 @@ class PrevWorkoutData {
       List<PrevSetWidget> setList = [];
       int i = 0;
       for (Sets _ in exercise.sets) {
-        setList.add(new PrevSetWidget(
+        setList.add(
+          PrevSetWidget(
             name: exercise.name,
             exercise: exercise,
             addNewSet: addSet,
             id: i,
-            isTemplate: workout.template));
+            isTemplate: workout.template,
+          ),
+        );
         i++;
       }
-      exerciseWidgets.add(new PrevExerciseCard(
-        name: exercise.name,
-        exercise: exercise,
-        addExercise: addExercise,
-        updateExisitingExercise: updateExisitingExercise,
-        isTemplate: workout.template,
-        setList: setList,
-        prevworkoutData: this,
-      ));
+      exerciseWidgets.add(
+        PrevExerciseCard(
+          name: exercise.name,
+          exercise: exercise,
+          addExercise: addExercise,
+          updateExisitingExercise: updateExisitingExercise,
+          isTemplate: workout.template,
+          setList: setList,
+          prevworkoutData: this,
+        ),
+      );
     }
+
     return exerciseWidgets;
   }
 
   updateExisitingExercise(exercise) {
     try {
-      totals = new WorkoutTotals(0, 0, 0, 0, 0);
+      totals = WorkoutTotals(0, 0, 0, 0, 0);
       for (Exercise oldexercise in workout.exercises) {
         totals.exercises++;
         if (oldexercise.name == exercise.name) {
@@ -107,7 +123,7 @@ class PrevWorkoutData {
       }
       updateTotals(workout);
     } catch (exception) {
-      Log.debug("problem:"+exception.toString());
+      Log.debug('problem:$exception');
     }
   }
 

--- a/lib/Models/sets.dart
+++ b/lib/Models/sets.dart
@@ -1,13 +1,14 @@
 
 
 class Sets {
+
+  Sets(this.reps, this.rest, this.weight, this.sets, this.percentage,);
+
   int reps;
   double rest;
   double weight;
   int sets;
   double percentage;
-
-  Sets(this.reps, this.rest, this.weight, this.sets, this.percentage);
 
   Map<dynamic, dynamic> toJson() {
     return { 'reps': reps, 'rest': rest, 'weight': weight, 'sets': sets, 'percentage': percentage};
@@ -19,6 +20,7 @@ class Sets {
       set['rest'],
       set['weight'],
       set['sets'],
-      set['percentage']);
+      set['percentage'],
+    );
   }
 }

--- a/lib/Models/user.dart
+++ b/lib/Models/user.dart
@@ -1,6 +1,21 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class UserClass {
+
+  UserClass(this.username, this.height, this.weight, this.age, this.email,
+      this.firstname, this.lastname, this.system, this.userID,);
+
+  UserClass.fromJson(Map<String, Object?> user)
+      : this.username = user['username']! as String,
+        this.height = user['height']! as double,
+        this.weight = user['weight']! as double,
+        this.age = user['age']! as int,
+        this.email = user['email']! as String,
+        this.firstname = user['firstname']! as String,
+        this.lastname = user['lastname'] as String,
+        this.system = user['system']! as String,
+        this.userID = user['userID']! as String;
+  
   String username;
   double weight;
   double height;
@@ -10,9 +25,6 @@ class UserClass {
   String lastname;
   String email;
   String userID;
-
-  UserClass(this.username, this.height, this.weight, this.age, this.email,
-      this.firstname, this.lastname, this.system, this.userID);
 
   Map<String, Object?> toJson() {
     return {
@@ -31,15 +43,4 @@ class UserClass {
   void setUserID(String id) {
     this.userID = id;
   }
-
-  UserClass.fromJson(Map<String, Object?> user)
-      : this.username = user['username']! as String,
-        this.height = user['height']! as double,
-        this.weight = user['weight']! as double,
-        this.age = user['age']! as int,
-        this.email = user['email']! as String,
-        this.firstname = user['firstname']! as String,
-        this.lastname = user['lastname'] as String,
-        this.system = user['system']! as String,
-        this.userID = user['userID']! as String;
 }

--- a/lib/Models/workout.dart
+++ b/lib/Models/workout.dart
@@ -3,18 +3,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'exercise.dart';
 
 class Workout {
-  List exercises;
-  String notes;
-  String rating;
-  double time;
-  String type;
-  String name;
-  bool template;
-  DateTime? date;
-  String? id;
-  int totalReps;
-  double totalWeight;
-  int totalSets;
 
   Workout(
       this.exercises,
@@ -26,31 +14,7 @@ class Workout {
       this.template,
       this.totalReps,
       this.totalWeight,
-      this.totalSets);
-
-  void setWorkoutTotals() {
-    for (Exercise exercise in exercises) {
-      totalReps += exercise.totalReps;
-      totalSets += exercise.totalSets;
-      totalWeight += exercise.totalWeight;
-    }
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'date': FieldValue.serverTimestamp(),
-      'exercises': exercises,
-      'notes': notes,
-      'rating': rating,
-      'time': time,
-      'type': type,
-      'total_reps': totalReps,
-      'total_weight': totalWeight,
-      'total_sets': totalSets,
-      'template': template,
-      'name': name
-    };
-  }
+      this.totalSets,);
 
   Workout.fromJson(Map<String, Object?> workout)
       : this.exercises = workout['exercises']! as List,
@@ -89,6 +53,41 @@ class Workout {
         this.name = workout.docs.last['name']! as String,
         this.type = workout.docs.last['type']! as String,
         this.template = workout.docs.last['template']! as bool;
-// getVolume()
-// getLoad()
+
+  List exercises;
+  String notes;
+  String rating;
+  double time;
+  String type;
+  String name;
+  bool template;
+  DateTime? date;
+  String? id;
+  int totalReps;
+  double totalWeight;
+  int totalSets;
+
+  void setWorkoutTotals() {
+    for (Exercise exercise in exercises) {
+      totalReps += exercise.totalReps;
+      totalSets += exercise.totalSets;
+      totalWeight += exercise.totalWeight;
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'date': FieldValue.serverTimestamp(),
+      'exercises': exercises,
+      'notes': notes,
+      'rating': rating,
+      'time': time,
+      'type': type,
+      'total_reps': totalReps,
+      'total_weight': totalWeight,
+      'total_sets': totalSets,
+      'template': template,
+      'name': name
+    };
+  }
 }

--- a/lib/Models/workout_data.dart
+++ b/lib/Models/workout_data.dart
@@ -8,27 +8,26 @@ import 'package:exerlog/src/utils/logger/logger.dart';
 import 'package:flutter/widgets.dart';
 
 class WorkoutData {
-  Function(Workout) updateTotals;
-  Workout workout;
-  WorkoutTotals totals;
-  List<ExerciseCard> exerciseWidgets = [];
-  static int key = 0;
 
   WorkoutData(this.workout, this.totals, this.updateTotals) {
     workout = this.workout;
 
-      loadWorkoutData().then((value) {
+      loadWorkoutData().then((Workout value) {
         workout = value;
         setExerciseWidgets();
         updateExisitingExercise();
       });
   }
 
+  Function(Workout) updateTotals;
+  Workout workout;
+  WorkoutTotals totals;
+  List<ExerciseCard> exerciseWidgets = [];
+  static int key = 0;
+
   addSet(exercise, newSet, id) {
     exercise.sets[id] = newSet;
-    //updateExisitingExercise(exercise);
     updateExisitingExercise();
-    //setExerciseWidgets();
   }
 
   removeSet(exercise, setToRemove,id) {
@@ -43,32 +42,34 @@ class WorkoutData {
 
   Future<Workout> loadWorkoutData() async {
     Workout loadedWorkout =
-        new Workout(workout.exercises, '', '', 0, '', '', true, 0, 0.0, 0);
+        Workout(workout.exercises, '', '', 0, '', '', true, 0, 0.0, 0);
         loadedWorkout.id = workout.id;
     List<Exercise> exerciseList = [];
     List<Exercise> newExerciseList = [];
     try {
       for (String exerciseId in workout.exercises) {
         await getSpecificExercise(exerciseId)
-            .then((value) async => {exerciseList.add(value)});
+            .then((Exercise value) async => {exerciseList.add(value)});
       }
-      Future.delayed(Duration(seconds: 3));
+      Future.delayed(const Duration(seconds: 3));
       int totalSets = 0;
       int totalReps = 0;
       double totalKgs = 0;
       int reps = 0;
       for (Exercise exercise in exerciseList) {
-        await getExerciseByName(exercise.name).then((newexercise) => {
-              for (Sets sets in newexercise.sets)
-                {
-                  totalSets += sets.sets,
-                  reps = sets.sets * sets.reps,
-                  totalReps += reps,
-                  totalKgs += reps * sets.weight
-                },
-              updateExisitingExercise(),
-              newExerciseList.add(newexercise)
-            });
+        await getExerciseByName(exercise.name).then(
+          (Exercise newexercise) => {
+            for (Sets sets in newexercise.sets)
+              {
+                totalSets += sets.sets,
+                reps = sets.sets * sets.reps,
+                totalReps += reps,
+                totalKgs += reps * sets.weight
+              },
+            updateExisitingExercise(),
+            newExerciseList.add(newexercise)
+          },
+        );
       }
       loadedWorkout.exercises = newExerciseList;
     } catch (exception) {
@@ -80,18 +81,20 @@ class WorkoutData {
   List<ExerciseCard> setExerciseWidgets() {
     exerciseWidgets = [];
     for (Exercise exercise in workout.exercises) {
-      exerciseWidgets.add(new ExerciseCard(
-        name: exercise.name,
-        exercise: exercise,
-        addExercise: addExercise,
-        updateExisitingExercise: updateExisitingExercise,
-        removeExercise: removeExercise,
-        removeSet: removeSet,
-        isTemplate: workout.template,
-        workoutData: this,
-        key: ValueKey(key),
-        totalsWidget: exercise.totalWidget,
-      ));
+      exerciseWidgets.add(
+        ExerciseCard(
+          name: exercise.name,
+          exercise: exercise,
+          addExercise: addExercise,
+          updateExisitingExercise: updateExisitingExercise,
+          removeExercise: removeExercise,
+          removeSet: removeSet,
+          isTemplate: workout.template,
+          workoutData: this,
+          key: ValueKey(key),
+          totalsWidget: exercise.totalWidget,
+        ),
+      );
       key++;
       for (Sets sets in exercise.sets) {
         totals.sets += sets.sets;
@@ -101,27 +104,25 @@ class WorkoutData {
         totals.avgKgs = (totals.weight / totals.reps).roundToDouble();
       }
     }
+
     return exerciseWidgets;
   }
 
   updateExisitingExercise() {
     try {
-      totals = new WorkoutTotals(0, 0, 0, 0, 0);
-
-      if (workout.exercises is List<Exercise>) {
-        for (Exercise oldexercise in workout.exercises) {
-          totals.exercises++;
-          for (Sets sets in oldexercise.sets) {
-            totals.sets += sets.sets;
-            int repsSet = sets.sets * sets.reps;
-            totals.weight += repsSet * sets.weight;
-            totals.reps += repsSet;
-          }
-          totals.avgKgs = (totals.weight / totals.reps).roundToDouble();
-          oldexercise.setExerciseTotals();
+      totals = WorkoutTotals(0, 0, 0, 0, 0);
+      for (Exercise oldexercise in workout.exercises) {
+        totals.exercises++;
+        for (Sets sets in oldexercise.sets) {
+          totals.sets += sets.sets;
+          int repsSet = sets.sets * sets.reps;
+          totals.weight += repsSet * sets.weight;
+          totals.reps += repsSet;
         }
-        updateTotals(workout);
+        totals.avgKgs = (totals.weight / totals.reps).roundToDouble();
+        oldexercise.setExerciseTotals();
       }
+      updateTotals(workout);
     } catch (exception) {
       Log.debug('problem:$exception');
     }
@@ -143,10 +144,10 @@ class WorkoutData {
       }
 
       if (exercise.name != '') {
-        await getExerciseByName(exercise.name).then((value) => {
-          workout.exercises.add(value),
-          setExerciseWidgets()
-        });
+        await getExerciseByName(exercise.name).then(
+          (Exercise value) =>
+              {workout.exercises.add(value), setExerciseWidgets()},
+        );
       }
     } catch (exception) {
       Log.debug(exception.toString());

--- a/lib/UI/exercise/add_exercise_widget.dart
+++ b/lib/UI/exercise/add_exercise_widget.dart
@@ -4,13 +4,12 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class ExerciseNameSelectionWidget extends StatefulWidget {
-  Function(String) setExercisename;
 
-  ExerciseNameSelectionWidget({
-    required this.setExercisename,
-  }) {
+  ExerciseNameSelectionWidget({required this.setExercisename, Key? key})
+      : super(key: key) {
     setExercisename = this.setExercisename;
   }
+  Function(String) setExercisename;
   @override
   _ExerciseNameSelectionWidgetState createState() => _ExerciseNameSelectionWidgetState();
 }
@@ -24,19 +23,19 @@ class _ExerciseNameSelectionWidgetState extends State<ExerciseNameSelectionWidge
           future: getExerciseNames(),
           builder: (BuildContext context, AsyncSnapshot<List<String>> snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
-              return Center(
+              return const Center(
                 child: CircularProgressIndicator(),
               );
             } else {
               if (snapshot.hasError) {
-                return Center(
+                return const Center(
                   child: Text('Error'),
                 );
               } else {
                 return Center(
                   child: Theme(
                     data: ThemeData(
-                        inputDecorationTheme: new InputDecorationTheme(
+                        inputDecorationTheme: InputDecorationTheme(
                           enabledBorder: UnderlineInputBorder(
                             borderSide: BorderSide(
                               color: theme.colorTheme.primaryColor,
@@ -53,9 +52,10 @@ class _ExerciseNameSelectionWidgetState extends State<ExerciseNameSelectionWidge
                             borderSide: BorderSide(color: theme.colorTheme.primaryColor),
                           ),
                         ),
-                        textTheme: TextTheme(
-                          subtitle1: setStyle,
-                        )),
+                      textTheme: TextTheme(
+                        subtitle1: setStyle,
+                      ),
+                    ),
                     child: Container(
                       child: Autocomplete<String>(
                         optionsMaxHeight: 100,
@@ -64,9 +64,11 @@ class _ExerciseNameSelectionWidgetState extends State<ExerciseNameSelectionWidge
                         },
                         optionsBuilder: (TextEditingValue textEditingValue) {
                           widget.setExercisename(textEditingValue.text);
-                          return snapshot.data!.where((String name) => name.toLowerCase().startsWith(
-                                textEditingValue.text.toLowerCase(),
-                              ));
+                          return snapshot.data!.where(
+                            (String name) => name.toLowerCase().startsWith(
+                                  textEditingValue.text.toLowerCase(),
+                                ),
+                          );
                         },
                       ),
                     ),

--- a/lib/UI/exercise/add_new_exercise_alert.dart
+++ b/lib/UI/exercise/add_new_exercise_alert.dart
@@ -5,13 +5,14 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class AddExerciseAlert extends StatelessWidget {
-  final ExerciseNameSelectionWidget nameWidget;
-  final RaisedGradientButton addExercise;
 
   const AddExerciseAlert(
     this.addExercise,
     this.nameWidget,
-  );
+      {Key? key,}
+  ) : super(key: key);
+  final ExerciseNameSelectionWidget nameWidget;
+  final RaisedGradientButton addExercise;
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(
@@ -20,7 +21,7 @@ class AddExerciseAlert extends StatelessWidget {
           backgroundColor: theme.colorTheme.backgroundColorVariation,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
           child: Container(
-            padding: EdgeInsets.all(15),
+            padding: const EdgeInsets.all(15),
             height: screenHeight * 0.4,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -31,7 +32,7 @@ class AddExerciseAlert extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
                 Container(
-                  padding: EdgeInsets.only(left: 20, right: 20),
+                  padding: const EdgeInsets.only(left: 20, right: 20),
                   child: nameWidget,
                 ),
                 Container(

--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -9,16 +9,6 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class ExerciseCard extends StatefulWidget {
-  final ValueKey key;
-  final String name;
-  Exercise exercise;
-  Function(Exercise) addExercise;
-  Function() updateExisitingExercise;
-  Function(Exercise) removeExercise;
-  Function(Exercise, Sets, int) removeSet;
-  final bool isTemplate;
-  WorkoutData workoutData;
-  ExerciseTotalsWidget totalsWidget;
 
   ExerciseCard({
     required this.key,
@@ -32,6 +22,20 @@ class ExerciseCard extends StatefulWidget {
     required this.workoutData,
     required this.totalsWidget,
   });
+
+  final ValueKey key;
+  final String name;
+  final bool isTemplate;
+
+  Exercise exercise;
+  WorkoutData workoutData;
+  ExerciseTotalsWidget totalsWidget;
+
+  Function(Exercise) addExercise;
+  Function() updateExisitingExercise;
+  Function(Exercise) removeExercise;
+  Function(Exercise, Sets, int) removeSet;
+
   @override
   _ExerciseCardState createState() => _ExerciseCardState();
 }
@@ -42,7 +46,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
   static int index = 0;
   double originalHeight = screenHeight * 0.23;
   double height = 0;
-  TotalsData totalData = new TotalsData(0, 0, 0.0, 0.0);
+  TotalsData totalData = TotalsData(0, 0, 0.0, 0.0);
   late ValueNotifier<TotalsData> _notifier;
 
   @override
@@ -52,31 +56,35 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
     originalHeight += getHeight() - 20;
     // widget.workoutData.addNewSet = addTheNewSet;
     if (widget.exercise.sets.isEmpty) {
-      setList.add(new SetWidget(
-        name: widget.name,
-        exercise: widget.exercise,
-        addNewSet: widget.workoutData.addSet,
-        removeSet: removeSet,
-        //createNewSet: createNewSet,
-        id: 0,
-        counter: counter,
-        isTemplate: widget.isTemplate,
-        updateTotal: updateTotal,
-      ));
-      widget.exercise.sets.add(new Sets(0, 0.0, 0.0, 0, 0.0));
-    } else if (widget.exercise.sets.isNotEmpty) {
-      int i = 0;
-      for (Sets _ in widget.exercise.sets) {
-        setList.add(new SetWidget(
-          name: widget.exercise.name,
+      setList.add(
+        SetWidget(
+          name: widget.name,
           exercise: widget.exercise,
           addNewSet: widget.workoutData.addSet,
           removeSet: removeSet,
+          //createNewSet: createNewSet,
+          id: 0,
           counter: counter,
-          id: i,
           isTemplate: widget.isTemplate,
           updateTotal: updateTotal,
-        ));
+        ),
+      );
+      widget.exercise.sets.add(Sets(0, 0.0, 0.0, 0, 0.0));
+    } else if (widget.exercise.sets.isNotEmpty) {
+      int i = 0;
+      for (Sets _ in widget.exercise.sets) {
+        setList.add(
+          SetWidget(
+            name: widget.exercise.name,
+            exercise: widget.exercise,
+            addNewSet: widget.workoutData.addSet,
+            removeSet: removeSet,
+            counter: counter,
+            id: i,
+            isTemplate: widget.isTemplate,
+            updateTotal: updateTotal,
+          ),
+        );
         counter++;
         i++;
       }
@@ -97,10 +105,10 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
             children: [
               Container(
                 decoration: BoxDecoration(
-                  borderRadius: BorderRadius.all(Radius.circular(20)),
+                  borderRadius: const BorderRadius.all(Radius.circular(20)),
                   color: theme.colorTheme.backgroundColorVariation,
                   boxShadow: [
-                    BoxShadow(
+                    const BoxShadow(
                       color: Color.fromRGBO(0, 0, 0, 0.2),
                       offset: Offset(0, 3),
                       blurRadius: 5,
@@ -108,8 +116,8 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                     ),
                   ],
                 ),
-                margin: EdgeInsets.only(left: 20, right: 20, top: 10, bottom: 10),
-                padding: EdgeInsets.all(20),
+                margin: const EdgeInsets.only(left: 20, right: 20, top: 10, bottom: 10),
+                padding: const EdgeInsets.all(20),
                 height: height,
                 child: Column(
                   children: [
@@ -150,44 +158,44 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              Spacer(flex: 8),
+                              const Spacer(flex: 8),
                               Expanded(
+                                flex: 15,
                                 child: Center(
                                   child: Text(
                                     'Reps',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                flex: 15,
                               ),
                               Expanded(
+                                flex: 15,
                                 child: Center(
                                   child: Text(
                                     'Sets',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                flex: 15,
                               ),
                               Expanded(
+                                flex: 15,
                                 child: Center(
                                   child: Text(
                                     'Weight',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                flex: 15,
                               ),
                               Expanded(
+                                flex: 15,
                                 child: Center(
                                   child: Text(
                                     'Rest',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                flex: 15,
                               ),
-                              Spacer(flex: 10)
+                              const Spacer(flex: 10)
                             ],
                           ),
                         ),
@@ -207,17 +215,18 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                   height: screenHeight * 0.07,
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: <Color>[
-                            theme.colorTheme.primaryColor,
-                            theme.colorTheme.secondaryColor,
-                          ],
-                        ),
-                        borderRadius: BorderRadius.circular(30)),
-                    child: CustomFloatingActionButton(
-                        icon: Icons.add,
-                        onTap: addSet,
+                      gradient: LinearGradient(
+                        colors: <Color>[
+                          theme.colorTheme.primaryColor,
+                          theme.colorTheme.secondaryColor,
+                        ],
                       ),
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    child: CustomFloatingActionButton(
+                      icon: Icons.add,
+                      onTap: addSet,
+                    ),
                   ),
                 ),
               ),
@@ -231,17 +240,19 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
   void addSet() {
     counter++;
     setState(() {
-      setList.add(new SetWidget(
-        name: widget.name,
-        exercise: widget.exercise,
-        addNewSet: widget.workoutData.addSet,
-        removeSet: removeSet,
-        counter: counter,
-        id: widget.exercise.sets.length,
-        isTemplate: false,
-        updateTotal: updateTotal,
-      ));
-      widget.exercise.sets.add(new Sets(0, 0.0, 0.0, 0, 0.0));
+      setList.add(
+        SetWidget(
+          name: widget.name,
+          exercise: widget.exercise,
+          addNewSet: widget.workoutData.addSet,
+          removeSet: removeSet,
+          counter: counter,
+          id: widget.exercise.sets.length,
+          isTemplate: false,
+          updateTotal: updateTotal,
+        ),
+      );
+      widget.exercise.sets.add(Sets(0, 0.0, 0.0, 0, 0.0));
       widget.addExercise(widget.exercise);
     });
     setHeight();
@@ -259,7 +270,8 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
         setList = [];
         int i = 0;
         for (Sets _ in widget.exercise.sets) {
-          setList.add(new SetWidget(
+          setList.add(
+            SetWidget(
               name: widget.exercise.name,
               exercise: widget.exercise,
               addNewSet: widget.workoutData.addSet,
@@ -267,7 +279,9 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
               counter: counter,
               id: i,
               isTemplate: widget.isTemplate,
-              updateTotal: updateTotal));
+              updateTotal: updateTotal,
+            ),
+          );
           counter++;
           i++;
         }
@@ -276,7 +290,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
   }
 
   void updateTotal() {
-    _notifier.value = new TotalsData(
+    _notifier.value = TotalsData(
       widget.exercise.totalReps,
       widget.exercise.totalSets,
       widget.exercise.totalWeight,

--- a/lib/UI/exercise/exercise_information.dart
+++ b/lib/UI/exercise/exercise_information.dart
@@ -3,12 +3,11 @@ import 'package:exerlog/Models/exercise.dart';
 import 'package:flutter/material.dart';
 
 class ExerciseInformation extends StatefulWidget {
+  const ExerciseInformation({required this.id, Key? key}) : super(key: key);
   final String id;
 
-  ExerciseInformation({required this.id});
   @override
   _ExerciseInformationState createState() => _ExerciseInformationState();
-
 }
 
 class _ExerciseInformationState extends State<ExerciseInformation> {
@@ -18,12 +17,12 @@ class _ExerciseInformationState extends State<ExerciseInformation> {
       future: getSpecificExercise(widget.id),
       builder: (BuildContext context, AsyncSnapshot<Exercise> snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return Center(
+          return const Center(
             child: CircularProgressIndicator(),
           );
         } else {
           if (snapshot.hasError) {
-            return Center(
+            return const Center(
               child: Text('Error'),
             );
           } else {

--- a/lib/UI/exercise/set_widget.dart
+++ b/lib/UI/exercise/set_widget.dart
@@ -3,34 +3,37 @@ import 'package:exerlog/Models/maxes.dart';
 import 'package:exerlog/Models/sets.dart';
 import 'package:exerlog/UI/global.dart';
 import 'package:exerlog/UI/maxes/max_builder.dart';
+import 'package:exerlog/src/utils/logger/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
 class SetWidget extends StatefulWidget {
+
+  SetWidget({
+    required this.name,
+    required this.exercise,
+    required this.addNewSet,
+    required this.removeSet,
+    required this.counter,
+    required this.id,
+    required this.isTemplate,
+    this.updateExercise,
+    required this.updateTotal,
+    Key? key,
+  }) : super(key: key);
+
   final String name;
   final Exercise exercise;
+  final counter;
+  final bool isTemplate;
+  int id;
+
   Function(Exercise, Sets, int) addNewSet;
   Function(Exercise, Sets, int) removeSet;
   Function? updateExercise;
   Function updateTotal;
-  final counter;
-  //Function(Sets, int) createNewSet;
-  final bool isTemplate;
-  int id;
 
-  SetWidget(
-      {required this.name,
-      required this.exercise,
-      required this.addNewSet,
-      required this.removeSet,
-      //required this.createNewSet,
-      required this.counter,
-      required this.id,
-      required this.isTemplate,
-      this.updateExercise,
-      required this.updateTotal
-      });
   @override
   _SetWidgetState createState() => _SetWidgetState();
 }
@@ -39,15 +42,15 @@ class _SetWidgetState extends State<SetWidget>
   with AutomaticKeepAliveClientMixin {
   int percent = 0;
   Max? oneRepMax;
-  Sets sets = new Sets(0, 0.0, 0.0, 0, 0.0);
+  Sets sets = Sets(0, 0.0, 0.0, 0, 0.0);
   String percentageController = '0%';
-  TextEditingController setsController = new TextEditingController();
-  TextEditingController repsController = new TextEditingController();
-  TextEditingController weightController = new TextEditingController();
-  TextEditingController restController = new TextEditingController();
+  TextEditingController setsController = TextEditingController();
+  TextEditingController repsController = TextEditingController();
+  TextEditingController weightController = TextEditingController();
+  TextEditingController restController = TextEditingController();
   List types = ['reps', 'sets', 'weight', 'rest', ''];
   MaxInformation? maxinfoWidget;
-  ValueNotifier<SetData> _notifier = ValueNotifier(new SetData(0.0, 0));
+  ValueNotifier<SetData> _notifier = ValueNotifier(SetData(0.0, 0));
 
   @override
   void initState() {
@@ -71,7 +74,7 @@ class _SetWidgetState extends State<SetWidget>
         key: ValueKey(widget.counter),
         endActionPane: ActionPane(
           // A motion is a widget used to control how the pane animates.
-          motion: ScrollMotion(),
+          motion: const ScrollMotion(),
 
           // A pane can dismiss the Slidable.
           //dismissible: DismissiblePane(onDismissed: () {}),
@@ -83,8 +86,8 @@ class _SetWidgetState extends State<SetWidget>
               onPressed: () {
                   widget.removeSet(widget.exercise, sets, widget.id);
               },
-              style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Color(0xFFFE4A49))),
-              child: Icon(Icons.delete, color: Colors.white,),
+              style: ButtonStyle(backgroundColor: MaterialStateProperty.all(const Color(0xFFFE4A49))),
+              child: const Icon(Icons.delete, color: Colors.white,),
             ),
           ],
         ),
@@ -95,37 +98,44 @@ class _SetWidgetState extends State<SetWidget>
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Expanded(
-                child: Center(
-                    child: Text(
-                  '#${widget.id + 1}',
-                  style: setStyle,
-                )),
                 flex: 8,
+                child: Center(
+                  child: Text(
+                    '#${widget.id + 1}',
+                    style: setStyle,
+                  ),
+                ),
               ),
               Expanded(
+                flex: 15,
                 child: getTextField(0),
-                flex: 15,
               ),
               Expanded(
+                flex: 15,
                 child: getTextField(1),
-                flex: 15,
               ),
               Expanded(
+                flex: 15,
                 child: getTextField(2),
-                flex: 15,
               ),
               Expanded(
+                flex: 15,
                 child: getTextField(3),
-                flex: 15,
               ),
               Expanded(
-                child: ValueListenableBuilder(
-                valueListenable: _notifier,
-                builder: (BuildContext context, SetData value, Widget? child) {
-                  return MaxInformation(id: widget.exercise.name, sets: widget.exercise.sets[widget.id], setMax: setOneRepMax, setPercentage: setPercentage);
-                }
-              ),
                 flex: 10,
+                child: ValueListenableBuilder(
+                  valueListenable: _notifier,
+                  builder:
+                      (BuildContext context, SetData value, Widget? child) {
+                    return MaxInformation(
+                      id: widget.exercise.name,
+                      sets: widget.exercise.sets[widget.id],
+                      setMax: setOneRepMax,
+                      setPercentage: setPercentage,
+                    );
+                  },
+                ),
               ),
             ],
           ),
@@ -163,7 +173,7 @@ class _SetWidgetState extends State<SetWidget>
           : [FilteringTextInputFormatter.digitsOnly],
       controller: controllers[type],
       decoration: InputDecoration(
-        focusedBorder: UnderlineInputBorder(
+        focusedBorder: const UnderlineInputBorder(
           borderSide: BorderSide(color: Colors.white),
         ),
         hintText: getHintText(type),
@@ -174,7 +184,7 @@ class _SetWidgetState extends State<SetWidget>
         sets.sets = getInfo(setsController.text, 0);
         if (weightController.text.contains('%')) {
           // set weight to be percentage of max
-          var regex = new RegExp(r'\D');
+          var regex = RegExp(r'\D');
           sets.weight = getWeightFromMax(weightController.text.replaceAll(regex, ''));
           weightController.text = sets.weight.toString();
         }
@@ -184,7 +194,7 @@ class _SetWidgetState extends State<SetWidget>
           sets.sets = 1;
         }
         widget.addNewSet(widget.exercise, sets, widget.id);
-        _notifier.value = new SetData(sets.weight, sets.reps);
+        _notifier.value = SetData(sets.weight, sets.reps);
         widget.updateTotal();
         //percent = (sets.weight / oneRepMax).round();
       },
@@ -223,7 +233,9 @@ class _SetWidgetState extends State<SetWidget>
     String returnText = '';
     try {
       returnText = listType[type].toString();
-    } catch (exception) {}
+    } catch (exception) {
+      Log.debug('hint error: $exception');
+    }
     return returnText;
   }
 
@@ -233,8 +245,8 @@ class _SetWidgetState extends State<SetWidget>
 }
 
 class SetData {
+  SetData(this.weight, this.reps);
+
   double weight;
   int reps;
-
-  SetData(this.weight, this.reps);
 }

--- a/lib/UI/exercise/totals_widget.dart
+++ b/lib/UI/exercise/totals_widget.dart
@@ -3,10 +3,11 @@ import 'package:exerlog/src/widgets/gradient_button.dart';
 import 'package:flutter/cupertino.dart';
 
 class ExerciseTotalsWidget extends StatefulWidget {
+
+  ExerciseTotalsWidget({required this.totals, required this.index,Key? key}) : super(key: key);
+
   TotalsData totals;
   int index;
-
-  ExerciseTotalsWidget({required this.totals, required this.index});
 
   @override
   _ExerciseTotalsWidgetState createState() => _ExerciseTotalsWidgetState();
@@ -14,7 +15,7 @@ class ExerciseTotalsWidget extends StatefulWidget {
 
 class _ExerciseTotalsWidgetState extends State<ExerciseTotalsWidget> {
   List _list = [];
-  List endings = [' reps', ' sets', ' kgs', ' kgs/rep'];
+  List<String> endings = [' reps', ' sets', ' kgs', ' kgs/rep'];
 
   @override
   Widget build(BuildContext context) {
@@ -28,11 +29,7 @@ class _ExerciseTotalsWidgetState extends State<ExerciseTotalsWidget> {
       height: screenHeight * 0.04,
       width: screenWidth * 0.3,
       child: RaisedGradientButton(
-        child: Text(
-          _list[widget.index].toString() + endings[widget.index],
-          style: buttonTextSmall,
-        ),
-        gradient: LinearGradient(
+        gradient: const LinearGradient(
           colors: <Color>[Color(0xFF34D1C2), Color(0xFF31A6DC)],
         ),
         onPressed: () {
@@ -44,16 +41,20 @@ class _ExerciseTotalsWidgetState extends State<ExerciseTotalsWidget> {
           });
         },
         radius: 30,
+        child: Text(
+          _list[widget.index].toString() + endings[widget.index],
+          style: buttonTextSmall,
+        ),
       ),
     );
   }
 }
 
 class TotalsData {
+  TotalsData(this.totalReps, this.totalSets, this.totalWeight, this.avgWeight);
+
   int totalReps;
   int totalSets;
   double totalWeight;
   double avgWeight;
-
-  TotalsData(this.totalReps, this.totalSets, this.totalWeight, this.avgWeight);
 }

--- a/lib/UI/global.dart
+++ b/lib/UI/global.dart
@@ -6,38 +6,38 @@ double screenHeight = 0.0;
 double screenWidth = 0.0;
 
 // text styles
-TextStyle whiteTextStyleSmall = TextStyle(
+TextStyle whiteTextStyleSmall = const TextStyle(
   color: Colors.white,
   fontFamily: 'Avenir',
   fontSize: 12,
 );
-TextStyle buttonTextSmall = TextStyle(
+TextStyle buttonTextSmall = const TextStyle(
   color: ThemeColor.darkBlueVariation,
   fontFamily: 'Avenir',
   fontWeight: FontWeight.w800,
   fontSize: 12,
 );
-TextStyle buttonText = TextStyle(
+TextStyle buttonText = const TextStyle(
   color: ThemeColor.darkBlueVariation,
   fontFamily: 'Avenir',
   fontWeight: FontWeight.w800,
   fontSize: 18,
 );
-TextStyle loginOptionTextStyle = TextStyle(
+TextStyle loginOptionTextStyle = const TextStyle(
   letterSpacing: 1,
   color: ThemeColor.grey,
   fontFamily: 'Avenir',
   fontWeight: FontWeight.w300,
   fontSize: 18,
 );
-TextStyle loginOptionTextStyleSelected = TextStyle(
+TextStyle loginOptionTextStyleSelected = const TextStyle(
   letterSpacing: 1,
   color: ThemeColor.secondary,
   fontFamily: 'Avenir',
   fontWeight: FontWeight.w400,
   fontSize: 18,
 );
-TextStyle mediumTitleStyleWhite = TextStyle(
+TextStyle mediumTitleStyleWhite = const TextStyle(
   letterSpacing: 1,
   color: Colors.white,
   fontFamily: 'Avenir',
@@ -50,20 +50,20 @@ TextStyle setHintStyle = TextStyle(
   fontFamily: 'Avenir',
   fontSize: 15,
 );
-TextStyle setStyle = TextStyle(
+TextStyle setStyle = const TextStyle(
   letterSpacing: 1,
   color: ThemeColor.primary,
   fontFamily: 'Avenir',
   fontSize: 15,
 );
-TextStyle greenButtonTextThin = TextStyle(
+TextStyle greenButtonTextThin = const TextStyle(
   letterSpacing: 1,
   color: ThemeColor.primary,
   fontFamily: 'Avenir',
   fontWeight: FontWeight.w300,
   fontSize: 18,
 );
-TextStyle smallTitleStyleWhite = TextStyle(
+TextStyle smallTitleStyleWhite = const TextStyle(
   letterSpacing: 1,
   color: Colors.white,
   fontFamily: 'Avenir',
@@ -72,7 +72,7 @@ TextStyle smallTitleStyleWhite = TextStyle(
 );
 
 // Dialog styles
-TextStyle dialogTitleStyle = new TextStyle(
+TextStyle dialogTitleStyle = const TextStyle(
   color: Colors.white,
   letterSpacing: 1,
   fontFamily: 'Avenir',
@@ -80,7 +80,7 @@ TextStyle dialogTitleStyle = new TextStyle(
   fontSize: 16,
 );
 
-TextStyle dialogDescriptionStyle = new TextStyle(
+TextStyle dialogDescriptionStyle = const TextStyle(
   color: Colors.white,
   letterSpacing: 1,
   fontFamily: 'Avenir',

--- a/lib/UI/gradient_border_button.dart
+++ b/lib/UI/gradient_border_button.dart
@@ -2,16 +2,8 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class GradientBorderButton extends StatefulWidget {
-  final Widget child;
-  final bool addButton;
-  final Gradient? gradient;
-  final double width;
-  final double height;
-  final Function onPressed;
-  final double radius;
-  final double borderSize;
 
-  GradientBorderButton({
+  const GradientBorderButton({
     required this.child,
     required this.onPressed,
     required this.radius,
@@ -20,7 +12,17 @@ class GradientBorderButton extends StatefulWidget {
     this.gradient,
     this.width = double.infinity,
     this.height = 50.0,
-  });
+    Key? key,
+  }) : super(key: key);
+
+  final Widget child;
+  final bool addButton;
+  final Gradient? gradient;
+  final double width;
+  final double height;
+  final Function onPressed;
+  final double radius;
+  final double borderSize;
   @override
   _GradientBorderButtonState createState() => _GradientBorderButtonState();
 }
@@ -41,25 +43,27 @@ class _GradientBorderButtonState extends State<GradientBorderButton> {
         Container cont2;
         if (widget.addButton) {
           cont = Container(
-              width: 30,
-              height: 30,
-              padding: EdgeInsets.all(widget.borderSize),
+            width: 30,
+            height: 30,
+            padding: EdgeInsets.all(widget.borderSize),
+            decoration: BoxDecoration(
+              gradient: gradient,
+              borderRadius: BorderRadius.circular(widget.radius / 2),
+            ),
+            child: Container(
               decoration: BoxDecoration(
-                gradient: gradient,
-                borderRadius: BorderRadius.circular(widget.radius / 2),
+                color: theme.colorTheme.backgroundColorVariation,
+                borderRadius: BorderRadius.circular(widget.radius),
               ),
-              child: Container(
-                child: Center(
-                    child: Icon(
+              child: Center(
+                child: Icon(
                   Icons.add,
                   color: theme.colorTheme.primaryColor,
                   size: 20,
-                )),
-                decoration: BoxDecoration(
-                  color: theme.colorTheme.backgroundColorVariation,
-                  borderRadius: BorderRadius.circular(widget.radius),
                 ),
-              ));
+              ),
+            ),
+          );
           cont2 = Container(
             width: 30,
           );
@@ -78,18 +82,18 @@ class _GradientBorderButtonState extends State<GradientBorderButton> {
               onPressed: () {
                 widget.onPressed();
               },
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [cont2, widget.child, cont],
-              ),
               style: ButtonStyle(
                 backgroundColor: MaterialStateProperty.all(theme.colorTheme.backgroundColorVariation),
                 shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                   RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(widget.radius),
-                    side: BorderSide(width: 0),
+                    side: const BorderSide(width: 0),
                   ),
                 ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [cont2, widget.child, cont],
               ),
             ),
           ),

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -11,7 +11,8 @@ class MaxInformation extends StatefulWidget {
     required this.sets,
     this.setMax,
     this.setPercentage,
-  });
+    Key? key,
+  }) : super(key: key);
 
   final String id;
   Sets sets;
@@ -33,7 +34,7 @@ class _MaxInformationState extends State<MaxInformation> {
       builder: (BuildContext context, AsyncSnapshot<Max> snapshot) {
         Sets sets = widget.sets;
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return Center(
+          return const Center(
             child: CircularProgressIndicator(),
           );
         } else {

--- a/lib/UI/prev_workout/delete_prev_workout_dialog.dart
+++ b/lib/UI/prev_workout/delete_prev_workout_dialog.dart
@@ -4,9 +4,9 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class DeleteWorkoutAlert extends StatefulWidget {
-  final RaisedGradientButton deleteWorkoutButton;
 
-  const DeleteWorkoutAlert(this.deleteWorkoutButton);
+  const DeleteWorkoutAlert(this.deleteWorkoutButton, {Key? key}) : super(key: key);
+  final RaisedGradientButton deleteWorkoutButton;
   @override
   _DeleteWorkoutAlertState createState() => _DeleteWorkoutAlertState();
 }
@@ -28,7 +28,7 @@ class _DeleteWorkoutAlertState extends State<DeleteWorkoutAlert> {
         backgroundColor: theme.colorTheme.backgroundColorVariation,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
         child: Container(
-          padding: EdgeInsets.all(15),
+          padding: const EdgeInsets.all(15),
           height: screenHeight * 0.4,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -47,6 +47,6 @@ class _DeleteWorkoutAlertState extends State<DeleteWorkoutAlert> {
           ),
         ),
       );
-    });
+    },);
   }
 }

--- a/lib/UI/prev_workout/prev_exercise_card.dart
+++ b/lib/UI/prev_workout/prev_exercise_card.dart
@@ -9,13 +9,6 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class PrevExerciseCard extends StatefulWidget {
-  final String name;
-  final Exercise exercise;
-  Function(Exercise) addExercise;
-  Function(Exercise) updateExisitingExercise;
-  final bool isTemplate;
-  List<PrevSetWidget> setList;
-  PrevWorkoutData prevworkoutData;
 
   PrevExerciseCard({
     required this.name,
@@ -25,7 +18,15 @@ class PrevExerciseCard extends StatefulWidget {
     required this.isTemplate,
     required this.setList,
     required this.prevworkoutData,
-  });
+    Key? key,
+  }) : super(key: key);
+  final String name;
+  final Exercise exercise;
+  Function(Exercise) addExercise;
+  Function(Exercise) updateExisitingExercise;
+  final bool isTemplate;
+  List<PrevSetWidget> setList;
+  PrevWorkoutData prevworkoutData;
   @override
   _PrevExerciseCardState createState() => _PrevExerciseCardState();
 }
@@ -33,7 +34,7 @@ class PrevExerciseCard extends StatefulWidget {
 class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepAliveClientMixin {
   int index = 0;
   double height = screenHeight * 0.23;
-  TotalsData totalData = new TotalsData(0, 0, 0.0, 0.0);
+  TotalsData totalData = TotalsData(0, 0, 0.0, 0.0);
   late ExerciseTotalsWidget totalWidget;
 
   @override
@@ -41,7 +42,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
     height += getHeight() - 20;
     if (widget.setList.isEmpty) {
       widget.setList.add(
-        new PrevSetWidget(
+        PrevSetWidget(
           name: widget.name,
           exercise: widget.exercise,
           addNewSet: widget.prevworkoutData.addNewSet,
@@ -49,7 +50,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
           isTemplate: widget.isTemplate,
         ),
       );
-      widget.exercise.sets.add(new Sets(0, 0.0, 0.0, 0, 0.0));
+      widget.exercise.sets.add(Sets(0, 0.0, 0.0, 0, 0.0));
     }
     totalWidget = widget.exercise.totalWidget;
     height += (screenHeight * 0.05) * (widget.setList.length - 1);
@@ -59,7 +60,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    totalWidget = new ExerciseTotalsWidget(totals: totalData, index: index);
+    totalWidget = ExerciseTotalsWidget(totals: totalData, index: index);
     return ThemeProvider(
       builder: (context, theme) {
         return Container(
@@ -68,10 +69,10 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
             children: [
               Container(
                 decoration: BoxDecoration(
-                  borderRadius: BorderRadius.all(Radius.circular(20)),
+                  borderRadius: const BorderRadius.all(Radius.circular(20)),
                   color: theme.colorTheme.backgroundColorVariation,
                   boxShadow: [
-                    BoxShadow(
+                    const BoxShadow(
                       color: Color.fromRGBO(0, 0, 0, 0.2),
                       offset: Offset(0, 3),
                       blurRadius: 5,
@@ -79,8 +80,8 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                     ),
                   ],
                 ),
-                margin: EdgeInsets.only(left: 20, right: 20, top: 10, bottom: 10),
-                padding: EdgeInsets.all(20),
+                margin: const EdgeInsets.only(left: 20, right: 20, top: 10, bottom: 10),
+                padding: const EdgeInsets.all(20),
                 height: height,
                 child: Column(
                   children: [
@@ -115,40 +116,40 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                                 width: screenWidth * 0.08,
                               ),
                               Container(
+                                width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
                                     'Reps',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
                               ),
                               Container(
+                                width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
                                     'Sets',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
                               ),
                               Container(
+                                width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
                                     'Weight',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
                               ),
                               Container(
+                                width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
                                     'Rest',
                                     style: smallTitleStyleWhite,
                                   ),
                                 ),
-                                width: screenWidth * 0.15,
                               ),
                               Container(
                                 width: screenWidth * 0.1,

--- a/lib/UI/prev_workout/prev_set_widget.dart
+++ b/lib/UI/prev_workout/prev_set_widget.dart
@@ -6,20 +6,23 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class PrevSetWidget extends StatefulWidget {
+
+  PrevSetWidget({
+    required this.name,
+    required this.exercise,
+    required this.addNewSet,
+    required this.id,
+    required this.isTemplate,
+    Key? key,
+  }) : super(key: key);
+
   final String name;
   final Exercise exercise;
-  Function(Exercise, Sets, int) addNewSet;
-  //Function(Sets, int) createNewSet;
   final bool isTemplate;
   int id;
 
-  PrevSetWidget(
-      {required this.name,
-      required this.exercise,
-      required this.addNewSet,
-      //required this.createNewSet,
-      required this.id,
-      required this.isTemplate});
+  Function(Exercise, Sets, int) addNewSet;
+
   @override
   _PrevSetWidgetState createState() => _PrevSetWidgetState();
 }
@@ -28,7 +31,7 @@ class _PrevSetWidgetState extends State<PrevSetWidget>
     with AutomaticKeepAliveClientMixin {
   int percent = 0;
   double oneRepMax = 0.0;
-  Sets sets = new Sets(0, 0.0, 0.0, 0, 0.0);
+  Sets sets = Sets(0, 0.0, 0.0, 0, 0.0);
   String setsController = '';
   String repsController = '';
   String weightController = '';
@@ -56,32 +59,33 @@ class _PrevSetWidgetState extends State<PrevSetWidget>
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Container(
+            width: screenWidth * 0.08,
             child: Center(
-                child: Text(
-              '#${widget.id + 1}',
-              style: setStyle,
-            )),
-            width: screenWidth * 0.08,
+              child: Text(
+                '#${widget.id + 1}',
+                style: setStyle,
+              ),
+            ),
           ),
           Container(
+            width: screenWidth * 0.145,
             child: getText(0),
-            width: screenWidth * 0.145,
           ),
           Container(
+            width: screenWidth * 0.145,
             child: getText(1),
-            width: screenWidth * 0.145,
           ),
           Container(
+            width: screenWidth * 0.145,
             child: getText(2),
-            width: screenWidth * 0.145,
           ),
           Container(
+            width: screenWidth * 0.145,
             child: getText(3),
-            width: screenWidth * 0.145,
           ),
           Container(
-            child: getText(4),
             width: screenWidth * 0.08,
+            child: getText(4),
           ),
         ],
       ),

--- a/lib/UI/prev_workout/prev_workout_page.dart
+++ b/lib/UI/prev_workout/prev_workout_page.dart
@@ -17,9 +17,9 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class PrevWorkoutPage extends StatefulWidget {
-  Workout workout;
 
-  PrevWorkoutPage(this.workout);
+  PrevWorkoutPage(this.workout, {Key? key}) : super(key: key);
+  Workout workout;
 
   @override
   _PrevWorkoutPageState createState() => _PrevWorkoutPageState();
@@ -34,9 +34,9 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
 
   @override
   void initState() {
-    Log.info("init");
+    Log.info('init');
     firstLoad = true;
-    newWorkout = new Workout(
+    newWorkout = Workout(
       [],
       '',
       '',
@@ -52,9 +52,9 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
     newWorkout.id = widget.workout.id;
 
     // TODO: implement initState
-    workoutData = new PrevWorkoutData(
+    workoutData = PrevWorkoutData(
       newWorkout,
-      new WorkoutTotals(0, 0, 0, 0, 0),
+      WorkoutTotals(0, 0, 0, 0, 0),
       updateTotals,
       addNewSet,
     );
@@ -70,7 +70,7 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
     screenHeight = MediaQuery.of(context).size.height;
     screenWidth = MediaQuery.of(context).size.width;
     //workoutData.workout = workout;
-    workoutTotalsWidget = new WorkoutTotalsWidget(totals: workoutData.totals);
+    workoutTotalsWidget = WorkoutTotalsWidget(totals: workoutData.totals);
     return ThemeProvider(
       builder: (context, theme) {
         return ThemeProvider(
@@ -144,21 +144,21 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
 
   showAlertDialogExercise(BuildContext context) {
     ExerciseNameSelectionWidget exerciseNameSelectionWidget =
-        new ExerciseNameSelectionWidget(
+        ExerciseNameSelectionWidget(
       setExercisename: setExercisename,
     );
     // set up the button
     RaisedGradientButton okButton = RaisedGradientButton(
       radius: 30,
       child: Text(
-        "ADD",
+        'ADD',
         style: buttonTextSmall,
       ),
       onPressed: () {
         if (exerciseName != '') {
           setState(() {
             workoutData
-                .addExercise(new Exercise(exerciseName, [], [], 0, 0, 0.0));
+                .addExercise(Exercise(exerciseName, [], [], 0, 0, 0.0));
             workoutData.setExerciseWidgets();
           });
           Navigator.pop(context);
@@ -189,16 +189,16 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
     RaisedGradientButton okButton = RaisedGradientButton(
       radius: 30,
       child: Text(
-        "SAVE",
+        'SAVE',
         style: buttonTextSmall,
       ),
       onPressed: () {
         saveWorkout(workoutData.workout);
         setState(() {
           firstLoad = true;
-          workoutData = new PrevWorkoutData(
-            new Workout([], '', '', 0, '', '', false, 0, 0.0, 0),
-            new WorkoutTotals(0, 0, 0, 0, 0),
+          workoutData = PrevWorkoutData(
+            Workout([], '', '', 0, '', '', false, 0, 0.0, 0),
+            WorkoutTotals(0, 0, 0, 0, 0),
             updateTotals,
             addNewSet,
           );
@@ -223,7 +223,7 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
     RaisedGradientButton okButton = RaisedGradientButton(
       radius: 30,
       child: Text(
-        "DELETE",
+        'DELETE',
         style: buttonTextSmall,
       ),
       onPressed: () {
@@ -253,9 +253,9 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
 
   addExercises(newWorkout) {
     setState(() {
-      PrevWorkoutData newWorkoutData = new PrevWorkoutData(
+      PrevWorkoutData newWorkoutData = PrevWorkoutData(
         newWorkout,
-        new WorkoutTotals(0, 0, 0, 0, 0),
+        WorkoutTotals(0, 0, 0, 0, 0),
         updateTotals,
         addNewSet,
       );
@@ -269,7 +269,7 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
     RaisedGradientButton viewButton = RaisedGradientButton(
       radius: 30,
       child: Text(
-        "VIEW",
+        'VIEW',
         style: buttonTextSmall,
       ),
       onPressed: () {
@@ -283,7 +283,7 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
       borderSize: 2,
       radius: 30,
       child: Text(
-        "REDO",
+        'REDO',
         style: whiteTextStyleSmall,
       ),
       onPressed: () {

--- a/lib/UI/workout/add_new_workout_alert.dart
+++ b/lib/UI/workout/add_new_workout_alert.dart
@@ -5,13 +5,14 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class AddWorkoutAlert extends StatelessWidget {
+
+  const AddWorkoutAlert(
+    this.addWorkout,
+    this.nameWidget, {
+    Key? key,
+  }) : super(key: key);
   final WorkoutTemplateSelectionWidget nameWidget;
   final RaisedGradientButton addWorkout;
-
-  AddWorkoutAlert(
-    this.addWorkout,
-    this.nameWidget,
-  );
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(
@@ -20,7 +21,7 @@ class AddWorkoutAlert extends StatelessWidget {
           backgroundColor: theme.colorTheme.backgroundColorVariation,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
           child: Container(
-            padding: EdgeInsets.all(15),
+            padding: const EdgeInsets.all(15),
             height: screenHeight * 0.4,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -32,7 +33,7 @@ class AddWorkoutAlert extends StatelessWidget {
                 ),
                 // new or template
                 Container(
-                  padding: EdgeInsets.only(left: 20, right: 20),
+                  padding: const EdgeInsets.only(left: 20, right: 20),
                   child: nameWidget,
                 ),
                 Container(

--- a/lib/UI/workout/redo_workout_alert.dart
+++ b/lib/UI/workout/redo_workout_alert.dart
@@ -5,50 +5,54 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class RedoWorkoutAlert extends StatelessWidget {
-  final RaisedGradientButton viewWorkout;
-  final GradientBorderButton redoWorkout;
   const RedoWorkoutAlert(
     this.viewWorkout,
     this.redoWorkout,
-  );
+      {Key? key,}
+  ) : super(key: key);
+  final RaisedGradientButton viewWorkout;
+  final GradientBorderButton redoWorkout;
   @override
   Widget build(BuildContext context) {
-    return ThemeProvider(builder: (context, theme) {
-      return Dialog(
-        backgroundColor: theme.colorTheme.backgroundColorVariation,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-        child: Container(
-          padding: EdgeInsets.all(15),
-          height: screenHeight * 0.2,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'Do you wanna view or redo?',
-                style: mediumTitleStyleWhite,
-                textAlign: TextAlign.center,
-              ),
-              // new or template
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Container(
-                    height: screenHeight * 0.05,
-                    width: screenWidth * 0.3,
-                    child: viewWorkout,
-                  ),
-                  Container(
-                    height: screenHeight * 0.05,
-                    width: screenWidth * 0.3,
-                    child: redoWorkout,
-                  ),
-                ],
-              ),
-            ],
+    return ThemeProvider(
+      builder: (context, theme) {
+        return Dialog(
+          backgroundColor: theme.colorTheme.backgroundColorVariation,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          child: Container(
+            padding: const EdgeInsets.all(15),
+            height: screenHeight * 0.2,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Do you wanna view or redo?',
+                  style: mediumTitleStyleWhite,
+                  textAlign: TextAlign.center,
+                ),
+                // new or template
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Container(
+                      height: screenHeight * 0.05,
+                      width: screenWidth * 0.3,
+                      child: viewWorkout,
+                    ),
+                    Container(
+                      height: screenHeight * 0.05,
+                      width: screenWidth * 0.3,
+                      child: redoWorkout,
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
   }
 }

--- a/lib/UI/workout/save_workout_dialog.dart
+++ b/lib/UI/workout/save_workout_dialog.dart
@@ -5,13 +5,14 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class SaveWorkoutAlert extends StatefulWidget {
-  final Function(String, bool) setWorkout;
-  final RaisedGradientButton saveWorkout;
 
   const SaveWorkoutAlert(
     this.saveWorkout,
     this.setWorkout,
-  );
+      {Key? key,}
+  ) : super(key: key);
+  final Function(String, bool) setWorkout;
+  final RaisedGradientButton saveWorkout;
   @override
   _SaveWorkoutAlertState createState() => _SaveWorkoutAlertState();
 }
@@ -36,7 +37,7 @@ class _SaveWorkoutAlertState extends State<SaveWorkoutAlert> {
             borderRadius: BorderRadius.circular(20),
           ),
           child: Container(
-            padding: EdgeInsets.all(15),
+            padding: const EdgeInsets.all(15),
             height: screenHeight * 0.4,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -47,27 +48,33 @@ class _SaveWorkoutAlertState extends State<SaveWorkoutAlert> {
                   textAlign: TextAlign.center,
                 ),
                 Container(
-                    padding: EdgeInsets.only(left: 20, right: 20),
-                    child: TextField(
-                      style: setStyle,
-                      onChanged: (value) {
-                        name = value;
-                        widget.setWorkout(name, template!);
-                      },
-                      decoration: InputDecoration(
-                        hintText: 'name your workout',
-                        hintStyle: setHintStyle,
-                        enabledBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(color: theme.colorTheme.primaryColor),
-                          //  when the TextFormField in unfocused
-                        ),
-                        focusedBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(color: theme.colorTheme.primaryColor),
-                          //  when the TextFormField in focused
-                        ),
-                        border: UnderlineInputBorder(borderSide: BorderSide(color: theme.colorTheme.primaryColor)),
+                  padding: const EdgeInsets.only(left: 20, right: 20),
+                  child: TextField(
+                    style: setStyle,
+                    onChanged: (value) {
+                      name = value;
+                      widget.setWorkout(name, template!);
+                    },
+                    decoration: InputDecoration(
+                      hintText: 'name your workout',
+                      hintStyle: setHintStyle,
+                      enabledBorder: UnderlineInputBorder(
+                        borderSide:
+                            BorderSide(color: theme.colorTheme.primaryColor),
+                        //  when the TextFormField in unfocused
                       ),
-                    )),
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide:
+                            BorderSide(color: theme.colorTheme.primaryColor),
+                        //  when the TextFormField in focused
+                      ),
+                      border: UnderlineInputBorder(
+                        borderSide:
+                            BorderSide(color: theme.colorTheme.primaryColor),
+                      ),
+                    ),
+                  ),
+                ),
                 Container(
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/UI/workout/workout_builder.dart
+++ b/lib/UI/workout/workout_builder.dart
@@ -6,9 +6,10 @@ import 'package:exerlog/UI/exercise/exercise_information.dart';
 import 'package:flutter/material.dart';
 
 class WorkoutInformation extends StatefulWidget {
-  final String id;
 
-  WorkoutInformation({required this.id});
+  const WorkoutInformation({required this.id,Key? key}) : super(key: key);
+
+  final String id;
   @override
   _WorkoutInformationState createState() => _WorkoutInformationState();
 
@@ -21,12 +22,12 @@ class _WorkoutInformationState extends State<WorkoutInformation> {
       future: getSpecificWorkout(widget.id),
       builder: (BuildContext context, AsyncSnapshot<Workout> snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return Center(
+          return const Center(
             child: CircularProgressIndicator(),
           );
         } else {
           if (snapshot.hasError) {
-            return Center(
+            return const Center(
               child: Text('Error'),
             );
           } else {

--- a/lib/UI/workout/workout_name_selection_widget.dart
+++ b/lib/UI/workout/workout_name_selection_widget.dart
@@ -5,12 +5,14 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class WorkoutTemplateSelectionWidget extends StatefulWidget {
-  Function(Workout) setWorkout;
-  List workoutList;
 
-  WorkoutTemplateSelectionWidget({required this.setWorkout, required this.workoutList}) {
+  WorkoutTemplateSelectionWidget(
+      {required this.setWorkout, required this.workoutList, Key? key,})
+      : super(key: key) {
     setWorkout = this.setWorkout;
   }
+  Function(Workout) setWorkout;
+  List workoutList;
   @override
   _WorkoutNameSelectionWidgetState createState() => _WorkoutNameSelectionWidgetState();
 }
@@ -25,22 +27,23 @@ class _WorkoutNameSelectionWidgetState extends State<WorkoutTemplateSelectionWid
         return Center(
           child: Theme(
             data: ThemeData(
-                inputDecorationTheme: new InputDecorationTheme(
-                  enabledBorder: UnderlineInputBorder(
-                    borderSide: BorderSide(color: theme.colorTheme.primaryColor),
-                    //  when the TextFormField in unfocused
-                  ),
-                  focusedBorder: UnderlineInputBorder(
-                    borderSide: BorderSide(color: theme.colorTheme.primaryColor),
-                    //  when the TextFormField in focused
-                  ),
-                  border: UnderlineInputBorder(
-                    borderSide: BorderSide(color: theme.colorTheme.primaryColor),
-                  ),
+              inputDecorationTheme: InputDecorationTheme(
+                enabledBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: theme.colorTheme.primaryColor),
+                  //  when the TextFormField in unfocused
                 ),
-                textTheme: TextTheme(
-                  subtitle1: setStyle,
-                )),
+                focusedBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: theme.colorTheme.primaryColor),
+                  //  when the TextFormField in focused
+                ),
+                border: UnderlineInputBorder(
+                  borderSide: BorderSide(color: theme.colorTheme.primaryColor),
+                ),
+              ),
+              textTheme: TextTheme(
+                subtitle1: setStyle,
+              ),
+            ),
             child: Container(
               width: screenWidth * 0.5,
               child: DropdownButton<String>(

--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -16,7 +16,7 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class WorkoutPage extends StatefulWidget {
-  WorkoutPage(this.workout);
+  WorkoutPage(this.workout, {Key? key}) : super(key: key);
 
   Workout? workout;
 
@@ -75,7 +75,7 @@ class _WorkoutPageState extends State<WorkoutPage> {
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(
-      builder: (context, theme) {
+      builder: (BuildContext context, AppTheme theme) {
         screenHeight = MediaQuery.of(context).size.height;
         screenWidth = MediaQuery.of(context).size.width;
         workoutTotalsWidget = WorkoutTotalsWidget(totals: workoutData.totals);
@@ -94,7 +94,7 @@ class _WorkoutPageState extends State<WorkoutPage> {
             ),
             actions: [
               Container(
-                margin: EdgeInsets.only(right: 5),
+                margin: const EdgeInsets.only(right: 5),
                 height: 30,
                 width: 30,
                 child: CustomFloatingActionButton(
@@ -110,6 +110,7 @@ class _WorkoutPageState extends State<WorkoutPage> {
                         workoutData.workout.exercises.remove(exercise);
                       }
                     }
+
                     if (workoutData.workout.exercises.isNotEmpty) {
                       showSaveWorkoutAlertDialog(context);
                     }
@@ -121,33 +122,40 @@ class _WorkoutPageState extends State<WorkoutPage> {
           body: firstLoad
               ? FutureBuilder(
                   future: getWorkoutTemplates(),
-                  builder: (BuildContext context,
-                      AsyncSnapshot<List<Workout>> snapshot) {
+                  builder: (
+                    BuildContext context,
+                    AsyncSnapshot<List<Workout>> snapshot,
+                  ) {
                     if (snapshot.connectionState == ConnectionState.waiting) {
-                      return Center(
+                      return const Center(
                         child: CircularProgressIndicator(),
                       );
                     } else {
                       if (snapshot.hasError) {
-                        return Center(
+                        return const Center(
                           child: Text('Something went wrong'),
                         );
                       } else {
                         if (snapshot.data!.isEmpty) {
                           firstLoad = false;
-                          Future.delayed(Duration.zero,
-                              () => showAlertDialogExercise(context));
+                          Future.delayed(
+                            Duration.zero,
+                            () => showAlertDialogExercise(context),
+                          );
                           return getPage(theme);
                         } else {
                           firstLoad = false;
                           workoutList = snapshot.data!;
-                          Future.delayed(Duration.zero,
-                              () => showAlertDialogWorkout(context));
+                          Future.delayed(
+                            Duration.zero,
+                            () => showAlertDialogWorkout(context),
+                          );
                           return getPage(theme);
                         }
                       }
                     }
-                  })
+                  },
+                )
               : getPage(theme),
         );
       },
@@ -157,7 +165,7 @@ class _WorkoutPageState extends State<WorkoutPage> {
   Widget getPage(AppTheme theme) {
     return GestureDetector(
       onTap: () {
-        FocusScope.of(context).requestFocus(new FocusNode());
+        FocusScope.of(context).requestFocus(FocusNode());
       },
       child: firstLoad
           ? Container(
@@ -221,11 +229,11 @@ class _WorkoutPageState extends State<WorkoutPage> {
     );
     // set up the button
     RaisedGradientButton okButton = RaisedGradientButton(
+      onPressed: addExercise,
       child: Text(
         'ADD',
         style: buttonTextSmall,
       ),
-      onPressed: addExercise,
     );
 
     /// Set up the AlertDialog

--- a/lib/UI/workout/workout_toatals_widget.dart
+++ b/lib/UI/workout/workout_toatals_widget.dart
@@ -3,9 +3,9 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class WorkoutTotalsWidget extends StatefulWidget {
-  final WorkoutTotals totals;
 
-  const WorkoutTotalsWidget({required this.totals});
+  const WorkoutTotalsWidget({Key? key, required this.totals}) : super(key: key);
+  final WorkoutTotals totals;
 
   @override
   _WorkoutTotalsWidgetState createState() => _WorkoutTotalsWidgetState();
@@ -19,15 +19,15 @@ class _WorkoutTotalsWidgetState extends State<WorkoutTotalsWidget> {
         return Container(
           height: screenHeight * 0.13,
           decoration: BoxDecoration(color: theme.colorTheme.backgroundColorVariation, boxShadow: [
-            BoxShadow(
+            const BoxShadow(
               color: Color.fromRGBO(0, 0, 0, 0.2),
               offset: Offset(0, 3),
               blurRadius: 5,
               spreadRadius: 5,
             ),
-          ]),
-          margin: EdgeInsets.only(bottom: 10),
-          padding: EdgeInsets.all(10),
+          ],),
+          margin: const EdgeInsets.only(bottom: 10),
+          padding: const EdgeInsets.all(10),
           child: Column(
             children: [
               Row(
@@ -137,11 +137,6 @@ class _WorkoutTotalsWidgetState extends State<WorkoutTotalsWidget> {
 }
 
 class WorkoutTotals {
-  int sets;
-  int reps;
-  double weight;
-  double avgKgs;
-  int exercises;
 
   WorkoutTotals(this.sets, this.reps, this.weight, this.avgKgs, this.exercises) {
     sets = this.sets;
@@ -150,4 +145,10 @@ class WorkoutTotals {
     avgKgs = this.avgKgs;
     exercises = this.exercises;
   }
+
+  int sets;
+  int reps;
+  double weight;
+  double avgKgs;
+  int exercises;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,33 +34,37 @@ void main() async {
   runApp(
     ProviderScope(
       observers: [RiverpodLogger()],
-      child: MyApp(),
+      child: const MyApp(),
     ),
   );
 }
 
 class MyApp extends ConsumerWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp(
       title: 'EXERLOG',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-          snackBarTheme: SnackBarThemeData(
-              backgroundColor: ThemeColor.red,
-              contentTextStyle: TextStyle(color: ThemeColor.secondary)),
-          scaffoldBackgroundColor: ThemeColor.darkBlueVariation,
-          dialogBackgroundColor: ThemeColor.darkBlueVariation,
-          appBarTheme: AppBarTheme(
-              backgroundColor: ThemeColor.darkBlue.withOpacity(0.75)),
-          colorScheme: ColorScheme.light().copyWith(
-            primary: ThemeColor.primary,
-            secondary: ThemeColor.secondary,
-            error: ThemeColor.red,
-            background: ThemeColor.darkBlueVariation,
-          )),
+        snackBarTheme: const SnackBarThemeData(
+          backgroundColor: ThemeColor.red,
+          contentTextStyle: TextStyle(color: ThemeColor.secondary),
+        ),
+        scaffoldBackgroundColor: ThemeColor.darkBlueVariation,
+        dialogBackgroundColor: ThemeColor.darkBlueVariation,
+        appBarTheme:
+            AppBarTheme(backgroundColor: ThemeColor.darkBlue.withOpacity(0.75)),
+        colorScheme: const ColorScheme.light().copyWith(
+          primary: ThemeColor.primary,
+          secondary: ThemeColor.secondary,
+          error: ThemeColor.red,
+          background: ThemeColor.darkBlueVariation,
+        ),
+      ),
       darkTheme: ThemeData(),
-      home: SplashScreen(),
+      home: const SplashScreen(),
     );
   }
 }

--- a/lib/src/core/base/base_state.dart
+++ b/lib/src/core/base/base_state.dart
@@ -15,6 +15,6 @@ class SuccessState extends BaseState {
 }
 
 class ErrorState extends BaseState {
-  final String? message;
   const ErrorState({this.message});
+  final String? message;
 }

--- a/lib/src/core/base/shared_preference/shared_pref_wrapper.dart
+++ b/lib/src/core/base/shared_preference/shared_pref_wrapper.dart
@@ -34,7 +34,7 @@ class SharedPref {
       return await sharedPreferences.setStringList(key, value);
     } else {
       throw ArgumentError(
-          'Invalid value ${value.runtimeType} - Must be a String, int, bool, double, Map<String, dynamic> or StringList');
+          'Invalid value ${value.runtimeType} - Must be a String, int, bool, double, Map<String, dynamic> or StringList',);
     }
   }
 
@@ -65,7 +65,7 @@ class SharedPref {
 
   /// Returns a JSON if exists in SharedPref
   static Map<String, dynamic> getJSONAsync(String key,
-      {Map<String, dynamic>? defaultValue}) {
+      {Map<String, dynamic>? defaultValue,}) {
     if (sharedPreferences.containsKey(key) &&
         sharedPreferences.getString(key)!.validate().isNotEmpty) {
       return jsonDecode(sharedPreferences.getString(key)!);

--- a/lib/src/core/theme/app_theme.dart
+++ b/lib/src/core/theme/app_theme.dart
@@ -2,9 +2,9 @@ import 'package:exerlog/src/core/theme/theme_color.dart';
 import 'package:flutter/material.dart';
 
 class AppTheme {
-  final ColorTheme colorTheme;
-
   const AppTheme._({required this.colorTheme});
+
+  final ColorTheme colorTheme;
 
   static const _darkInstance = AppTheme._(
     colorTheme: ColorTheme(
@@ -34,20 +34,13 @@ class AppTheme {
 
   static AppTheme of(BuildContext context) {
     final platformBrightness = MediaQuery.of(context).platformBrightness;
-    return platformBrightness == Brightness.dark ? _darkInstance : _lightInstance;
+    return platformBrightness == Brightness.dark
+        ? _darkInstance
+        : _lightInstance;
   }
 }
 
 class ColorTheme {
-  final Color primaryColor;
-  final Color secondaryColor;
-  final Color backgroundColor;
-  final Color backgroundColorVariation;
-  final Color error;
-  final Color disabled;
-  final Color white;
-  final Color shadow;
-
   const ColorTheme({
     required this.primaryColor,
     required this.secondaryColor,
@@ -58,4 +51,13 @@ class ColorTheme {
     required this.white,
     required this.shadow,
   });
+
+  final Color primaryColor;
+  final Color secondaryColor;
+  final Color backgroundColor;
+  final Color backgroundColorVariation;
+  final Color error;
+  final Color disabled;
+  final Color white;
+  final Color shadow;
 }

--- a/lib/src/dependency.dart
+++ b/lib/src/dependency.dart
@@ -21,4 +21,4 @@ final _googleSignInProvider = Provider<GoogleSignIn?>((ref) => GoogleSignIn());
 final _connectivityProvider = Provider<Connectivity>((ref) => Connectivity());
 
 final _onConnectivityChangedStreamProvider = StreamProvider<ConnectivityResult>(
-    (ref) => ref.read(_connectivityProvider).onConnectivityChanged);
+    (ref) => ref.read(_connectivityProvider).onConnectivityChanged,);

--- a/lib/src/feature/authentication/controller/authentication_controller.dart
+++ b/lib/src/feature/authentication/controller/authentication_controller.dart
@@ -13,7 +13,7 @@ final _authenticationProvider =
 );
 
 class AuthenticationController extends StateNotifier<BaseState> {
-  AuthenticationController({this.ref}) : super(InitialState()) {
+  AuthenticationController({this.ref}) : super(const InitialState()) {
     _repository = ref!.watch(AuthenticationRepository.provider);
   }
 
@@ -29,7 +29,7 @@ class AuthenticationController extends StateNotifier<BaseState> {
 
   Future<void> signIn() async {
     try {
-      state = LoadingState();
+      state = const LoadingState();
       await _repository.signIn(
         email: emailTextEditingController.text,
         password: passwordTextEditingController.text,
@@ -44,7 +44,7 @@ class AuthenticationController extends StateNotifier<BaseState> {
 
   Future<void> signUp() async {
     try {
-      state = LoadingState();
+      state = const LoadingState();
       await _repository.signUp(
         email: emailTextEditingController.text,
         password: passwordTextEditingController.text,
@@ -60,7 +60,7 @@ class AuthenticationController extends StateNotifier<BaseState> {
   /// TODO: Need to decide if it's signIn / signUp
   Future<void> signInWithGoogle() async {
     try {
-      state = LoadingState();
+      state = const LoadingState();
       await _repository.signInWithGoogle();
       authStateChangeStatus();
     } on FirebaseAuthException catch (exception) {
@@ -70,7 +70,7 @@ class AuthenticationController extends StateNotifier<BaseState> {
     } catch (exception, stackTrace) {
       Log.error(exception.toString(), stackTrace: stackTrace);
 
-      state = ErrorState(message: 'Something went wrong');
+      state = const ErrorState(message: 'Something went wrong');
     }
   }
 
@@ -85,12 +85,12 @@ class AuthenticationController extends StateNotifier<BaseState> {
       Log.info(this.user.uid);
 
       if (isSignUp) {
-        state = SignUpSuccessState();
+        state = const SignUpSuccessState();
       } else {
-        state = LoginSuccessState();
+        state = const LoginSuccessState();
       }
     } else {
-      state = ErrorState(message: 'Something went wrong');
+      state = const ErrorState(message: 'Something went wrong');
     }
   }
 

--- a/lib/src/feature/authentication/data/authentication_repository.dart
+++ b/lib/src/feature/authentication/data/authentication_repository.dart
@@ -18,12 +18,12 @@ class AuthenticationRepository {
 
   Future signIn({required String email, password}) async {
     await _firebaseAuth.signInWithEmailAndPassword(
-        email: email, password: password);
+        email: email, password: password,);
   }
 
   Future<void> signUp({required String email, password}) async {
     await _firebaseAuth.createUserWithEmailAndPassword(
-        email: email, password: password);
+        email: email, password: password,);
   }
 
   Future<void> signInWithGoogle() async {

--- a/lib/src/feature/authentication/view/landing_screen.dart
+++ b/lib/src/feature/authentication/view/landing_screen.dart
@@ -97,14 +97,10 @@ class _LandingScreenState extends ConsumerState<LandingScreen> with SingleTicker
                     ],
                   ),
                 ),
-                SizedBox(height: 20),
+                const SizedBox(height: 20),
 
                 /// Login / Sign up button
                 RaisedGradientButton(
-                  child: Text(
-                    _tabIndex > 0 ? 'Sign up' : 'Login',
-                    style: buttonText,
-                  ),
                   width: context.width * .65,
                   onPressed: () async {
                     if (_tabIndex == 0) {
@@ -121,8 +117,12 @@ class _LandingScreenState extends ConsumerState<LandingScreen> with SingleTicker
                       }
                     }
                   },
+                  child: Text(
+                    _tabIndex > 0 ? 'Sign up' : 'Login',
+                    style: buttonText,
+                  ),
                 ),
-                SizedBox(height: 20),
+                const SizedBox(height: 20),
               ],
             ),
           ),
@@ -134,7 +134,7 @@ class _LandingScreenState extends ConsumerState<LandingScreen> with SingleTicker
   void _navigateToCalendarScreen() {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(
-        builder: (context) => CalendarScreen(),
+        builder: (context) => const CalendarScreen(),
       ),
     );
   }

--- a/lib/src/feature/authentication/widgets/elevated_container.dart
+++ b/lib/src/feature/authentication/widgets/elevated_container.dart
@@ -17,14 +17,14 @@ class ElevatedContainer extends StatelessWidget {
         return Center(
           child: Container(
             height: context.height * 0.50,
-            margin: EdgeInsets.symmetric(horizontal: 30),
+            margin: const EdgeInsets.symmetric(horizontal: 30),
             decoration: BoxDecoration(
               color: theme.colorTheme.backgroundColorVariation,
-              borderRadius: BorderRadius.all(Radius.circular(10)),
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
               boxShadow: [
                 BoxShadow(
                   color: theme.colorTheme.shadow,
-                  offset: Offset(0, 3),
+                  offset: const Offset(0, 3),
                   blurRadius: 10,
                   spreadRadius: 10,
                 )

--- a/lib/src/feature/authentication/widgets/google_signin_button.dart
+++ b/lib/src/feature/authentication/widgets/google_signin_button.dart
@@ -6,7 +6,7 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class GoogleSignInButton extends StatefulWidget {
-  GoogleSignInButton({required this.onPressed});
+  GoogleSignInButton({Key? key, required this.onPressed}) : super(key: key);
 
   final FutureOr Function() onPressed;
 
@@ -26,6 +26,14 @@ class _GoogleSignInButtonState extends State<GoogleSignInButton> {
           width: context.width * .65,
           child: OutlinedButton(
             onPressed: _onPressed,
+            style: ButtonStyle(
+              backgroundColor: MaterialStateProperty.all(theme.colorTheme.white),
+              shape: MaterialStateProperty.all(
+                RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30),
+                ),
+              ),
+            ),
             child: _isLoading
                 ? Center(
                     child: CircularProgressIndicator(
@@ -37,12 +45,12 @@ class _GoogleSignInButtonState extends State<GoogleSignInButton> {
                     mainAxisSize: MainAxisSize.min,
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
-                      Image(
+                      const Image(
                         image: AssetImage(Assets.googleLogo),
                         height: 20.0,
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(left: 10),
+                      const Padding(
+                        padding: EdgeInsets.only(left: 10),
                         child: Text(
                           'Sign in with Google',
                           style: TextStyle(
@@ -54,17 +62,9 @@ class _GoogleSignInButtonState extends State<GoogleSignInButton> {
                       )
                     ],
                   ),
-            style: ButtonStyle(
-              backgroundColor: MaterialStateProperty.all(theme.colorTheme.white),
-              shape: MaterialStateProperty.all(
-                RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-              ),
-            ),
           ),
         );
-      }
+      },
     );
   }
 

--- a/lib/src/feature/authentication/widgets/login_form.dart
+++ b/lib/src/feature/authentication/widgets/login_form.dart
@@ -5,7 +5,7 @@ import 'package:exerlog/src/widgets/text_field.dart';
 import 'package:flutter/material.dart';
 
 class LoginForm extends StatelessWidget {
-  const LoginForm(this.controller);
+  const LoginForm(this.controller, {Key? key}) : super(key: key);
 
   final AuthenticationController controller;
 
@@ -14,7 +14,7 @@ class LoginForm extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        Spacer(),
+        const Spacer(),
         OutlinedTextField(
           hinText: 'Email',
           leadingIcon: Icons.email,
@@ -28,7 +28,7 @@ class LoginForm extends StatelessWidget {
           textEditingController: controller.passwordTextEditingController,
           obscureText: true,
         ),
-        Spacer(),
+        const Spacer(),
         GoogleSignInButton(onPressed: controller.signInWithGoogle)
       ],
     );

--- a/lib/src/feature/authentication/widgets/signup_form.dart
+++ b/lib/src/feature/authentication/widgets/signup_form.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../widgets/text_field.dart';
 
 class SignupForm extends StatelessWidget {
-  SignupForm(this.controller);
+  SignupForm(this.controller, {Key? key}) : super(key: key);
 
   final AuthenticationController controller;
 

--- a/lib/src/feature/calendar/view/calendar_screen.dart
+++ b/lib/src/feature/calendar/view/calendar_screen.dart
@@ -14,6 +14,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class CalendarScreen extends ConsumerStatefulWidget {
+  const CalendarScreen({Key? key}) : super(key: key);
+
   @override
   ConsumerState<CalendarScreen> createState() => _CalendarScreenState();
 }
@@ -37,26 +39,26 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
         return Scaffold(
           backgroundColor: colorTheme.backgroundColorVariation,
           appBar: AppBar(
-            title: Text(Texts.appName),
+            title: const Text(Texts.appName),
             backgroundColor:
                 colorTheme.backgroundColorVariation.withOpacity(0.75),
             actions: [
-              LogoutButton(),
+              const LogoutButton(),
             ],
           ),
           body: Padding(
-            padding: EdgeInsets.all(15),
+            padding: const EdgeInsets.all(15),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 CalendarWidget(),
                 RaisedGradientButton(
+                  width: context.width * .8,
+                  onPressed: _navigateToWorkoutScreen,
                   child: Text(
                     Texts.startNewWorkout.toUpperCase(),
                     style: buttonTextSmall,
                   ),
-                  width: context.width * .8,
-                  onPressed: _navigateToWorkoutScreen,
                 )
               ],
             ),

--- a/lib/src/feature/calendar/widgets/calendar_widget.dart
+++ b/lib/src/feature/calendar/widgets/calendar_widget.dart
@@ -25,18 +25,18 @@ class CalendarWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(
-      builder: (context, theme) {
+      builder: (BuildContext context, AppTheme theme) {
         ColorTheme colorTheme = theme.colorTheme;
         return FittedBox(
           child: Container(
-            padding: EdgeInsets.all(20),
+            padding: const EdgeInsets.all(20),
             width: context.width,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(10),
               boxShadow: [
                 BoxShadow(
                   color: colorTheme.shadow,
-                  offset: Offset(0, 3),
+                  offset: const Offset(0, 3),
                   blurRadius: 5,
                   spreadRadius: 5,
                 ),
@@ -88,12 +88,12 @@ List<Widget> _getDateColumns() {
   DateTime now = DateTime.now();
   const int daysInAWeek = 7;
 
-  List<List<DateTime>> weekList = List.generate(daysInAWeek, (index) => []);
+  List<List<DateTime>> weekList = List.generate(daysInAWeek, (int index) => []);
 
   /// Month could span 4-6 weeks which is 4-6 columns
   /// which day of the week does the first fall on
   DateTime first = now.subtract(Duration(days: today - 1));
-  DateTime last = new DateTime(year, month + 1, 0);
+  DateTime last = DateTime(year, month + 1, 0);
 
   /// If the first of the month falls anywhere else than on a monday
   /// then get the dates before the first as well

--- a/lib/src/feature/calendar/widgets/date_widget.dart
+++ b/lib/src/feature/calendar/widgets/date_widget.dart
@@ -8,9 +8,9 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class DateWidget extends StatelessWidget {
-  final DateTime date;
 
-  DateWidget(this.date);
+  const DateWidget(this.date, {Key? key}) : super(key: key);
+  final DateTime date;
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +36,7 @@ class DateWidget extends StatelessWidget {
     );
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: getWorkoutOnDate(after, before),
-      builder: (context, snapshot) {
+      builder: (BuildContext context, AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> snapshot) {
         if (!snapshot.hasData) {
           return _buildDayContainer();
         }
@@ -60,10 +60,10 @@ class DateWidget extends StatelessWidget {
 
   Widget _buildDayContainer({bool hasWorkout = false}) {
     return ThemeProvider(
-      builder: (context, theme) {
+      builder: (BuildContext context, AppTheme theme) {
         return Container(
-          margin: EdgeInsets.all(5),
-          padding: EdgeInsets.all(10),
+          margin: const EdgeInsets.all(5),
+          padding: const EdgeInsets.all(10),
           decoration:
               hasWorkout ? _hasWorkoutDecoration(theme.colorTheme) : null,
           child: Center(
@@ -91,11 +91,11 @@ class DateWidget extends StatelessWidget {
   }
 
   void _navigateToPreviousWorkoutScreen(context, Workout? workout) {
-    if (workout != null)
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (context) => PrevWorkoutPage(workout),
-        ),
-      );
+    if (workout == null) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (BuildContext context) => PrevWorkoutPage(workout),
+      ),
+    );
   }
 }

--- a/lib/src/feature/calendar/widgets/logout_button.dart
+++ b/lib/src/feature/calendar/widgets/logout_button.dart
@@ -17,7 +17,7 @@ class _LogoutButtonState extends State<LogoutButton> with Dialogs {
       padding: const EdgeInsets.only(right: 16.0),
       child: InkWell(
         onTap: signOutConfirmationDialog,
-        child: Icon(Icons.logout),
+        child: const Icon(Icons.logout),
       ),
     );
   }

--- a/lib/src/feature/onboarding/splash/view/splash_screen.dart
+++ b/lib/src/feature/onboarding/splash/view/splash_screen.dart
@@ -19,7 +19,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    Timer(Duration(milliseconds: 2000), () {
+    Timer(const Duration(milliseconds: 2000), () {
       if (SharedPref.getBoolAsync(IS_LOGGED_IN, defaultValue: false)) {
         if (mounted) _navigateToCalendarScreen();
       } else {
@@ -55,7 +55,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(
-        builder: (context) => LandingScreen(),
+        builder: (context) => const LandingScreen(),
       ),
     );
   }
@@ -63,7 +63,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   void _navigateToCalendarScreen() {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(
-        builder: (context) => CalendarScreen(),
+        builder: (context) => const CalendarScreen(),
       ),
     );
   }

--- a/lib/src/utils/logger/logger.dart
+++ b/lib/src/utils/logger/logger.dart
@@ -1,7 +1,6 @@
 import 'package:logger/logger.dart';
 
 class Log {
-  late Logger _logger;
 
   Log._loggerType({loggerType = 'simple'}) {
     switch (loggerType) {
@@ -11,19 +10,22 @@ class Log {
         break;
       case 'pretty':
         _logger = Logger(
-            printer: PrettyPrinter(
-                methodCount: 2,
-                // number of method calls to be displayed
-                errorMethodCount: 8,
-                // number of method calls if stacktrace is provided
-                lineLength: 120,
-                // width of the output
-                colors: true,
-                // Colorful log messages
-                printEmojis: true,
-                // Print an emoji for each log message
-                printTime: false // Should each log print contain a timestamp
-                ));
+          printer: PrettyPrinter(
+            methodCount: 2,
+            // number of method calls to be displayed
+            errorMethodCount: 8,
+            // number of method calls if stacktrace is provided
+            lineLength: 120,
+            // width of the output
+            colors: true,
+            // Colorful log messages
+            printEmojis: true,
+            // Print an emoji for each log message
+            printTime: false
+            // Should each log print contain a timestamp
+            ,
+          ),
+        );
         break;
       case 'fmt':
         _logger = Logger(printer: LogfmtPrinter());
@@ -36,6 +38,7 @@ class Log {
         throw ArgumentError('config for logger $loggerType not exists');
     }
   }
+  late Logger _logger;
 
   static final Log _singleton = Log._loggerType();
 

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -2,15 +2,15 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class CustomFloatingActionButton extends StatelessWidget {
-  final IconData icon;
-  final VoidCallback onTap;
-  final double size;
-
-  CustomFloatingActionButton({
+  const CustomFloatingActionButton({
+    Key? key,
     required this.icon,
     required this.onTap,
     this.size = 50.0,
-  });
+  }) : super(key: key);
+  final IconData icon;
+  final VoidCallback onTap;
+  final double size;
 
   @override
   Widget build(BuildContext context) => ThemeProvider(
@@ -23,7 +23,7 @@ class CustomFloatingActionButton extends StatelessWidget {
                 color: theme.colorTheme.shadow,
                 blurRadius: 10,
                 spreadRadius: 2,
-                offset: Offset(0, 0),
+                offset: const Offset(0, 0),
               ),
             ],
           ),

--- a/lib/src/widgets/dialogs.dart
+++ b/lib/src/widgets/dialogs.dart
@@ -13,7 +13,7 @@ mixin Dialogs<T extends StatefulWidget> on State<T> {
     required List<Widget> actions,
   }) {
     return ThemeProvider(
-      builder: (context, theme) => new AlertDialog(
+      builder: (context, theme) => AlertDialog(
         backgroundColor: theme.colorTheme.backgroundColorVariation,
         title: Text(
           title,
@@ -32,7 +32,7 @@ mixin Dialogs<T extends StatefulWidget> on State<T> {
     void _navigateToLandingScreen(BuildContext context) {
       Navigator.pushAndRemoveUntil(
         context,
-        MaterialPageRoute(builder: (context) => LandingScreen()),
+        MaterialPageRoute(builder: (context) => const LandingScreen()),
         (route) => false,
       );
     }
@@ -48,7 +48,7 @@ mixin Dialogs<T extends StatefulWidget> on State<T> {
             onPressed: () {
               Navigator.pop(context);
             },
-            child: Text('Cancel'),
+            child: const Text('Cancel'),
           ),
           TextButton(
             onPressed: () async {
@@ -57,7 +57,7 @@ mixin Dialogs<T extends StatefulWidget> on State<T> {
               await FirebaseAuth.instance.signOut();
               _navigateToLandingScreen(context);
             },
-            child: Text('Sign Out'),
+            child: const Text('Sign Out'),
           ),
         ],
       ),

--- a/lib/src/widgets/gradient_button.dart
+++ b/lib/src/widgets/gradient_button.dart
@@ -4,14 +4,15 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class RaisedGradientButton extends StatefulWidget {
-  RaisedGradientButton({
+  const RaisedGradientButton({
     required this.onPressed,
     required this.child,
+    Key? key,
     this.width = double.infinity,
     this.height = 50.0,
     this.radius = 30,
     this.gradient,
-  });
+  }) : super(key: key);
 
   final FutureOr Function() onPressed;
   final Widget child;
@@ -48,7 +49,7 @@ class _RaisedGradientButtonState extends State<RaisedGradientButton> {
             child: TextButton(
               onPressed: _onPressed,
               child: _isLoading
-                  ? Center(
+                  ? const Center(
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
                         valueColor: AlwaysStoppedAnimation<Color>(Colors.white),

--- a/lib/src/widgets/snack_bars/no_network_connection_snackbar.dart
+++ b/lib/src/widgets/snack_bars/no_network_connection_snackbar.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 SnackBar noNetworkConnectionSnackBar(AppTheme theme) => SnackBar(
       backgroundColor: theme.colorTheme.error,
-      duration: Duration(days: 365), // set to a year so that it doesn't disappear automatically untill the user clicks on the Dismiss button
-      content: Text('No network connection, please check your connection'),
+      duration: const Duration(days: 365), // set to a year so that it doesn't disappear automatically untill the user clicks on the Dismiss button
+      content: const Text('No network connection, please check your connection'),
       action: SnackBarAction(
         textColor: theme.colorTheme.secondaryColor,
         label: 'Dismiss',

--- a/lib/src/widgets/text_field.dart
+++ b/lib/src/widgets/text_field.dart
@@ -45,7 +45,7 @@ class OutlinedTextField extends StatelessWidget {
                   color: theme.colorTheme.primaryColor,
                 ),
               ),
-              contentPadding: EdgeInsets.all(10),
+              contentPadding: const EdgeInsets.all(10),
               focusedErrorBorder: _outlineInputBorder,
               focusedBorder: _outlineInputBorder,
               errorBorder: _outlineInputBorder,

--- a/lib/src/widgets/theme/theme_provider.dart
+++ b/lib/src/widgets/theme/theme_provider.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 typedef ThemeBuilder = Widget Function(BuildContext context, AppTheme theme);
 
 class ThemeProvider extends StatefulWidget {
-  final ThemeBuilder builder;
 
   const ThemeProvider({
     required this.builder,
     Key? key,
   }) : super(key: key);
+  final ThemeBuilder builder;
 
   @override
   State<ThemeProvider> createState() => _ThemeProviderState();

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,9 +11,9 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           title: 'EXERLOG',
           home: Container(
-            child: Text('EXERLOG'),
+            child: const Text('EXERLOG'),
           ),
-        ));
+        ),);
       });
     }
 


### PR DESCRIPTION
### Summary

refactor code to pass following linter rules:
- prefer_is_empty
- avoid empty catch
- curly_braces_in_flow_control_structures
- unnecessary_new
- use_key_in_widget_constructors
- sort_child_properties_last
- sort_constructors_first
- prefer_const_constructors
- always_specify_types
- require_trailing_commas
