### PR TITLE
refactor: sized_box_for_whitespace linter rule

### DIFF
--- a/lib/UI/exercise/add_new_exercise_alert.dart
+++ b/lib/UI/exercise/add_new_exercise_alert.dart
@@ -35,7 +35,7 @@ class AddExerciseAlert extends StatelessWidget {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: nameWidget,
                 ),
-                Container(
+                SizedBox(
                   height: screenHeight * 0.05,
                   width: screenWidth * 0.5,
                   child: addExercise,

--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -99,7 +99,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
     super.build(context);
     return ThemeProvider(
       builder: (context, theme) {
-        return Container(
+        return SizedBox(
           height: height + screenHeight * 0.06,
           child: Stack(
             children: [
@@ -125,7 +125,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Container(
+                          SizedBox(
                             height: getHeight(),
                             width: screenWidth * 0.45,
                             child: Text(
@@ -153,7 +153,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                     ),
                     Column(
                       children: [
-                        Container(
+                        SizedBox(
                           height: screenHeight * 0.04,
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -211,7 +211,7 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                 right: screenWidth * 0.43,
                 left: screenWidth * 0.43,
                 top: height - 15,
-                child: Container(
+                child: SizedBox(
                   height: screenHeight * 0.07,
                   child: DecoratedBox(
                     decoration: BoxDecoration(

--- a/lib/UI/exercise/set_widget.dart
+++ b/lib/UI/exercise/set_widget.dart
@@ -92,7 +92,7 @@ class _SetWidgetState extends State<SetWidget>
           ],
         ),
 
-        child: Container(
+        child: SizedBox(
           height: screenHeight * 0.05,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/UI/exercise/totals_widget.dart
+++ b/lib/UI/exercise/totals_widget.dart
@@ -25,7 +25,7 @@ class _ExerciseTotalsWidgetState extends State<ExerciseTotalsWidget> {
       widget.totals.totalWeight,
       widget.totals.avgWeight
     ];
-    return Container(
+    return SizedBox(
       height: screenHeight * 0.04,
       width: screenWidth * 0.3,
       child: RaisedGradientButton(

--- a/lib/UI/prev_workout/delete_prev_workout_dialog.dart
+++ b/lib/UI/prev_workout/delete_prev_workout_dialog.dart
@@ -38,7 +38,7 @@ class _DeleteWorkoutAlertState extends State<DeleteWorkoutAlert> {
                 style: mediumTitleStyleWhite,
                 textAlign: TextAlign.center,
               ),
-              Container(
+              SizedBox(
                 height: screenHeight * 0.05,
                 width: screenWidth * 0.5,
                 child: widget.deleteWorkoutButton,

--- a/lib/UI/prev_workout/prev_exercise_card.dart
+++ b/lib/UI/prev_workout/prev_exercise_card.dart
@@ -63,7 +63,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
     totalWidget = ExerciseTotalsWidget(totals: totalData, index: index);
     return ThemeProvider(
       builder: (context, theme) {
-        return Container(
+        return SizedBox(
           height: height + screenHeight * 0.06,
           child: Stack(
             children: [
@@ -89,7 +89,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Container(
+                          SizedBox(
                             height: getHeight(),
                             width: screenWidth * 0.45,
                             child: Text(
@@ -107,7 +107,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                     ),
                     Column(
                       children: [
-                        Container(
+                        SizedBox(
                           height: screenHeight * 0.04,
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -115,7 +115,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                               Container(
                                 width: screenWidth * 0.08,
                               ),
-                              Container(
+                              SizedBox(
                                 width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
@@ -124,7 +124,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                                   ),
                                 ),
                               ),
-                              Container(
+                              SizedBox(
                                 width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
@@ -133,7 +133,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                                   ),
                                 ),
                               ),
-                              Container(
+                              SizedBox(
                                 width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(
@@ -142,7 +142,7 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                                   ),
                                 ),
                               ),
-                              Container(
+                              SizedBox(
                                 width: screenWidth * 0.15,
                                 child: Center(
                                   child: Text(

--- a/lib/UI/prev_workout/prev_set_widget.dart
+++ b/lib/UI/prev_workout/prev_set_widget.dart
@@ -52,13 +52,13 @@ class _PrevSetWidgetState extends State<PrevSetWidget>
     return getSetWidget();
   }
 
-  Container getSetWidget() {
-    return Container(
+  SizedBox getSetWidget() {
+    return SizedBox(
       height: screenHeight * 0.05,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Container(
+          SizedBox(
             width: screenWidth * 0.08,
             child: Center(
               child: Text(
@@ -67,23 +67,23 @@ class _PrevSetWidgetState extends State<PrevSetWidget>
               ),
             ),
           ),
-          Container(
+          SizedBox(
             width: screenWidth * 0.145,
             child: getText(0),
           ),
-          Container(
+          SizedBox(
             width: screenWidth * 0.145,
             child: getText(1),
           ),
-          Container(
+          SizedBox(
             width: screenWidth * 0.145,
             child: getText(2),
           ),
-          Container(
+          SizedBox(
             width: screenWidth * 0.145,
             child: getText(3),
           ),
-          Container(
+          SizedBox(
             width: screenWidth * 0.08,
             child: getText(4),
           ),

--- a/lib/UI/workout/add_new_workout_alert.dart
+++ b/lib/UI/workout/add_new_workout_alert.dart
@@ -36,7 +36,7 @@ class AddWorkoutAlert extends StatelessWidget {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: nameWidget,
                 ),
-                Container(
+                SizedBox(
                   height: screenHeight * 0.05,
                   width: screenWidth * 0.5,
                   child: addWorkout,

--- a/lib/UI/workout/redo_workout_alert.dart
+++ b/lib/UI/workout/redo_workout_alert.dart
@@ -36,12 +36,12 @@ class RedoWorkoutAlert extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Container(
+                    SizedBox(
                       height: screenHeight * 0.05,
                       width: screenWidth * 0.3,
                       child: viewWorkout,
                     ),
-                    Container(
+                    SizedBox(
                       height: screenHeight * 0.05,
                       width: screenWidth * 0.3,
                       child: redoWorkout,

--- a/lib/UI/workout/save_workout_dialog.dart
+++ b/lib/UI/workout/save_workout_dialog.dart
@@ -99,7 +99,7 @@ class _SaveWorkoutAlertState extends State<SaveWorkoutAlert> {
                     ],
                   ),
                 ),
-                Container(
+                SizedBox(
                   height: screenHeight * 0.05,
                   width: screenWidth * 0.5,
                   child: widget.saveWorkout,

--- a/lib/UI/workout/workout_name_selection_widget.dart
+++ b/lib/UI/workout/workout_name_selection_widget.dart
@@ -44,7 +44,7 @@ class _WorkoutNameSelectionWidgetState extends State<WorkoutTemplateSelectionWid
                 subtitle1: setStyle,
               ),
             ),
-            child: Container(
+            child: SizedBox(
               width: screenWidth * 0.5,
               child: DropdownButton<String>(
                 value: dropDownValue,

--- a/lib/src/feature/authentication/view/landing_screen.dart
+++ b/lib/src/feature/authentication/view/landing_screen.dart
@@ -81,7 +81,7 @@ class _LandingScreenState extends ConsumerState<LandingScreen> with SingleTicker
             child: Column(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                Container(
+                SizedBox(
                   height: 40,
                   child: TabBar(
                     tabs: tabs,

--- a/lib/src/widgets/custom_floating_action_button.dart
+++ b/lib/src/widgets/custom_floating_action_button.dart
@@ -32,7 +32,7 @@ class CustomFloatingActionButton extends StatelessWidget {
             child: InkWell(
               onTap: onTap,
               borderRadius: BorderRadius.circular(size),
-              child: Container(
+              child: SizedBox(
                 width: size,
                 height: size,
                 child: Center(

--- a/lib/src/widgets/text_field.dart
+++ b/lib/src/widgets/text_field.dart
@@ -38,7 +38,7 @@ class OutlinedTextField extends StatelessWidget {
               hintStyle: setHintStyle.copyWith(
                 color: Colors.white.withOpacity(0.5),
               ),
-              prefixIcon: Container(
+              prefixIcon: SizedBox(
                 width: 40,
                 child: Icon(
                   leadingIcon,


### PR DESCRIPTION
### Summary

Use SizedBox to add whitespace to a layout.

A Container is a heavier Widget than a SizedBox, and as bonus, SizedBox has a const constructor.


refactor code to pass following linter rules:

- sized_box_for_whitespace

