### PR TITLE
refactor: avoid_unnecessary_containers linter rule

### DIFF
--- a/lib/UI/exercise/add_exercise_widget.dart
+++ b/lib/UI/exercise/add_exercise_widget.dart
@@ -56,21 +56,19 @@ class _ExerciseNameSelectionWidgetState extends State<ExerciseNameSelectionWidge
                         subtitle1: setStyle,
                       ),
                     ),
-                    child: Container(
-                      child: Autocomplete<String>(
-                        optionsMaxHeight: 100,
-                        onSelected: (value) {
-                          widget.setExercisename(value);
-                        },
-                        optionsBuilder: (TextEditingValue textEditingValue) {
-                          widget.setExercisename(textEditingValue.text);
-                          return snapshot.data!.where(
-                            (String name) => name.toLowerCase().startsWith(
-                                  textEditingValue.text.toLowerCase(),
-                                ),
-                          );
-                        },
-                      ),
+                    child: Autocomplete<String>(
+                      optionsMaxHeight: 100,
+                      onSelected: (value) {
+                        widget.setExercisename(value);
+                      },
+                      optionsBuilder: (TextEditingValue textEditingValue) {
+                        widget.setExercisename(textEditingValue.text);
+                        return snapshot.data!.where(
+                          (String name) => name.toLowerCase().startsWith(
+                                textEditingValue.text.toLowerCase(),
+                              ),
+                        );
+                      },
                     ),
                   ),
                 );

--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -121,31 +121,27 @@ class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClie
                 height: height,
                 child: Column(
                   children: [
-                    Container(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Container(
-                            height: getHeight(),
-                            width: screenWidth * 0.45,
-                            child: Text(
-                              widget.name,
-                              style: mediumTitleStyleWhite,
-                            ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Container(
+                          height: getHeight(),
+                          width: screenWidth * 0.45,
+                          child: Text(
+                            widget.name,
+                            style: mediumTitleStyleWhite,
                           ),
-                          Container(
-                            child: ValueListenableBuilder(
-                              valueListenable: _notifier,
-                              builder: (BuildContext context, TotalsData value, Widget? child) {
-                                return ExerciseTotalsWidget(
-                                  totals: value,
-                                  index: index,
-                                );
-                              },
-                            ),
-                          ),
-                        ],
-                      ),
+                        ),
+                        ValueListenableBuilder(
+                          valueListenable: _notifier,
+                          builder: (BuildContext context, TotalsData value, Widget? child) {
+                            return ExerciseTotalsWidget(
+                              totals: value,
+                              index: index,
+                            );
+                          },
+                        ),
+                      ],
                     ),
                     Divider(
                       thickness: 1,

--- a/lib/UI/prev_workout/prev_exercise_card.dart
+++ b/lib/UI/prev_workout/prev_exercise_card.dart
@@ -85,21 +85,19 @@ class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepA
                 height: height,
                 child: Column(
                   children: [
-                    Container(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Container(
-                            height: getHeight(),
-                            width: screenWidth * 0.45,
-                            child: Text(
-                              widget.name,
-                              style: mediumTitleStyleWhite,
-                            ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Container(
+                          height: getHeight(),
+                          width: screenWidth * 0.45,
+                          child: Text(
+                            widget.name,
+                            style: mediumTitleStyleWhite,
                           ),
-                          totalWidget
-                        ],
-                      ),
+                        ),
+                        totalWidget
+                      ],
                     ),
                     Divider(
                       thickness: 1,

--- a/lib/UI/prev_workout/prev_workout_page.dart
+++ b/lib/UI/prev_workout/prev_workout_page.dart
@@ -108,12 +108,9 @@ class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
                               totals: workoutData.totals,
                             ),
                             Expanded(
-                              child: Container(
-                                //height: screenHeight * 0.5,
-                                child: ListView(
-                                  addAutomaticKeepAlives: true,
-                                  children: workoutData.exerciseWidgets,
-                                ),
+                              child: ListView(
+                                addAutomaticKeepAlives: true,
+                                children: workoutData.exerciseWidgets,
                               ),
                             ),
                           ],

--- a/lib/UI/workout/save_workout_dialog.dart
+++ b/lib/UI/workout/save_workout_dialog.dart
@@ -75,29 +75,25 @@ class _SaveWorkoutAlertState extends State<SaveWorkoutAlert> {
                     ),
                   ),
                 ),
-                Container(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Container(
-                        child: Text(
-                          'Save as template',
-                          style: mediumTitleStyleWhite,
-                        ),
-                      ),
-                      Checkbox(
-                        fillColor: MaterialStateProperty.all<Color>(theme.colorTheme.primaryColor),
-                        value: this.template,
-                        onChanged: (bool? value) {
-                          setState(() {
-                            Log.info(value.toString());
-                            template = value;
-                            widget.setWorkout(name, template!);
-                          });
-                        },
-                      ),
-                    ],
-                  ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Save as template',
+                      style: mediumTitleStyleWhite,
+                    ),
+                    Checkbox(
+                      fillColor: MaterialStateProperty.all<Color>(theme.colorTheme.primaryColor),
+                      value: this.template,
+                      onChanged: (bool? value) {
+                        setState(() {
+                          Log.info(value.toString());
+                          template = value;
+                          widget.setWorkout(name, template!);
+                        });
+                      },
+                    ),
+                  ],
                 ),
                 Container(
                   height: screenHeight * 0.05,

--- a/lib/UI/workout/workout_toatals_widget.dart
+++ b/lib/UI/workout/workout_toatals_widget.dart
@@ -32,11 +32,9 @@ class _WorkoutTotalsWidgetState extends State<WorkoutTotalsWidget> {
             children: [
               Row(
                 children: [
-                  Container(
-                    child: Text(
-                      'Totals',
-                      style: mediumTitleStyleWhite,
-                    ),
+                  Text(
+                    'Totals',
+                    style: mediumTitleStyleWhite,
                   )
                 ],
               ),
@@ -48,81 +46,61 @@ class _WorkoutTotalsWidgetState extends State<WorkoutTotalsWidget> {
                 children: [
                   Column(
                     children: [
-                      Container(
-                        child: Text(
-                          'sets',
-                          style: setStyle,
-                        ),
+                      Text(
+                        'sets',
+                        style: setStyle,
                       ),
-                      Container(
-                        child: Text(
-                          widget.totals.sets.toString(),
-                          style: setStyle,
-                        ),
+                      Text(
+                        widget.totals.sets.toString(),
+                        style: setStyle,
                       )
                     ],
                   ),
                   Column(
                     children: [
-                      Container(
-                        child: Text(
-                          'reps',
-                          style: setStyle,
-                        ),
+                      Text(
+                        'reps',
+                        style: setStyle,
                       ),
-                      Container(
-                        child: Text(
-                          widget.totals.reps.toString(),
-                          style: setStyle,
-                        ),
+                      Text(
+                        widget.totals.reps.toString(),
+                        style: setStyle,
                       )
                     ],
                   ),
                   Column(
                     children: [
-                      Container(
-                        child: Text(
-                          'load',
-                          style: setStyle,
-                        ),
+                      Text(
+                        'load',
+                        style: setStyle,
                       ),
-                      Container(
-                        child: Text(
-                          widget.totals.weight.toString(),
-                          style: setStyle,
-                        ),
+                      Text(
+                        widget.totals.weight.toString(),
+                        style: setStyle,
                       )
                     ],
                   ),
                   Column(
                     children: [
-                      Container(
-                        child: Text(
-                          'kg/rep',
-                          style: setStyle,
-                        ),
+                      Text(
+                        'kg/rep',
+                        style: setStyle,
                       ),
-                      Container(
-                        child: Text(
-                          widget.totals.avgKgs.toString(),
-                          style: setStyle,
-                        ),
+                      Text(
+                        widget.totals.avgKgs.toString(),
+                        style: setStyle,
                       )
                     ],
                   ),
                   Column(
                     children: [
-                      Container(
-                        child: Text(
-                          'exercises',
-                          style: setStyle,
-                        ),
+                      Text(
+                        'exercises',
+                        style: setStyle,
                       ),
-                      Container(
-                        child: Text(
-                          widget.totals.exercises.toString(),
-                          style: setStyle,
-                        ),
+                      Text(
+                        widget.totals.exercises.toString(),
+                        style: setStyle,
                       )
                     ],
                   ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,9 +10,7 @@ void main() {
       await tester.runAsync(() async {
         await tester.pumpWidget(MaterialApp(
           title: 'EXERLOG',
-          home: Container(
-            child: const Text('EXERLOG'),
-          ),
+          home: const Text('EXERLOG'),
         ),);
       });
     }


### PR DESCRIPTION
### Summary

AVOID wrapping widgets in unnecessary containers.

Wrapping a widget in Container with no other parameters set has no effect and makes code needlessly more complex.
