### PR TITLE
refactor: library_private_types_in_public_api linter rule

### DIFF
--- a/lib/UI/exercise/add_exercise_widget.dart
+++ b/lib/UI/exercise/add_exercise_widget.dart
@@ -11,10 +11,10 @@ class ExerciseNameSelectionWidget extends StatefulWidget {
   }
   Function(String) setExercisename;
   @override
-  _ExerciseNameSelectionWidgetState createState() => _ExerciseNameSelectionWidgetState();
+  ExerciseNameSelectionWidgetState createState() => ExerciseNameSelectionWidgetState();
 }
 
-class _ExerciseNameSelectionWidgetState extends State<ExerciseNameSelectionWidget> {
+class ExerciseNameSelectionWidgetState extends State<ExerciseNameSelectionWidget> {
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(

--- a/lib/UI/exercise/exercise_card.dart
+++ b/lib/UI/exercise/exercise_card.dart
@@ -37,10 +37,10 @@ class ExerciseCard extends StatefulWidget {
   Function(Exercise, Sets, int) removeSet;
 
   @override
-  _ExerciseCardState createState() => _ExerciseCardState();
+  ExerciseCardState createState() => ExerciseCardState();
 }
 
-class _ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClientMixin {
+class ExerciseCardState extends State<ExerciseCard> with AutomaticKeepAliveClientMixin {
   static int counter = 0;
   List<SetWidget> setList = [];
   static int index = 0;

--- a/lib/UI/exercise/exercise_information.dart
+++ b/lib/UI/exercise/exercise_information.dart
@@ -7,10 +7,10 @@ class ExerciseInformation extends StatefulWidget {
   final String id;
 
   @override
-  _ExerciseInformationState createState() => _ExerciseInformationState();
+  ExerciseInformationState createState() => ExerciseInformationState();
 }
 
-class _ExerciseInformationState extends State<ExerciseInformation> {
+class ExerciseInformationState extends State<ExerciseInformation> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<Exercise>(

--- a/lib/UI/exercise/set_widget.dart
+++ b/lib/UI/exercise/set_widget.dart
@@ -35,10 +35,10 @@ class SetWidget extends StatefulWidget {
   Function updateTotal;
 
   @override
-  _SetWidgetState createState() => _SetWidgetState();
+  SetWidgetState createState() => SetWidgetState();
 }
 
-class _SetWidgetState extends State<SetWidget>
+class SetWidgetState extends State<SetWidget>
   with AutomaticKeepAliveClientMixin {
   int percent = 0;
   Max? oneRepMax;

--- a/lib/UI/exercise/totals_widget.dart
+++ b/lib/UI/exercise/totals_widget.dart
@@ -10,10 +10,10 @@ class ExerciseTotalsWidget extends StatefulWidget {
   int index;
 
   @override
-  _ExerciseTotalsWidgetState createState() => _ExerciseTotalsWidgetState();
+  ExerciseTotalsWidgetState createState() => ExerciseTotalsWidgetState();
 }
 
-class _ExerciseTotalsWidgetState extends State<ExerciseTotalsWidget> {
+class ExerciseTotalsWidgetState extends State<ExerciseTotalsWidget> {
   List _list = [];
   List<String> endings = [' reps', ' sets', ' kgs', ' kgs/rep'];
 

--- a/lib/UI/gradient_border_button.dart
+++ b/lib/UI/gradient_border_button.dart
@@ -24,10 +24,10 @@ class GradientBorderButton extends StatefulWidget {
   final double radius;
   final double borderSize;
   @override
-  _GradientBorderButtonState createState() => _GradientBorderButtonState();
+  GradientBorderButtonState createState() => GradientBorderButtonState();
 }
 
-class _GradientBorderButtonState extends State<GradientBorderButton> {
+class GradientBorderButtonState extends State<GradientBorderButton> {
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(

--- a/lib/UI/maxes/max_builder.dart
+++ b/lib/UI/maxes/max_builder.dart
@@ -20,10 +20,10 @@ class MaxInformation extends StatefulWidget {
   Function? setPercentage;
 
   @override
-  _MaxInformationState createState() => _MaxInformationState();
+  MaxInformationState createState() => MaxInformationState();
 }
 
-class _MaxInformationState extends State<MaxInformation> {
+class MaxInformationState extends State<MaxInformation> {
   double oneRepMax = 0.0;
   String text = '0%';
 

--- a/lib/UI/prev_workout/delete_prev_workout_dialog.dart
+++ b/lib/UI/prev_workout/delete_prev_workout_dialog.dart
@@ -8,10 +8,10 @@ class DeleteWorkoutAlert extends StatefulWidget {
   const DeleteWorkoutAlert(this.deleteWorkoutButton, {Key? key}) : super(key: key);
   final RaisedGradientButton deleteWorkoutButton;
   @override
-  _DeleteWorkoutAlertState createState() => _DeleteWorkoutAlertState();
+  DeleteWorkoutAlertState createState() => DeleteWorkoutAlertState();
 }
 
-class _DeleteWorkoutAlertState extends State<DeleteWorkoutAlert> {
+class DeleteWorkoutAlertState extends State<DeleteWorkoutAlert> {
   String name = '';
   bool? template;
 

--- a/lib/UI/prev_workout/prev_exercise_card.dart
+++ b/lib/UI/prev_workout/prev_exercise_card.dart
@@ -28,10 +28,10 @@ class PrevExerciseCard extends StatefulWidget {
   List<PrevSetWidget> setList;
   PrevWorkoutData prevworkoutData;
   @override
-  _PrevExerciseCardState createState() => _PrevExerciseCardState();
+  PrevExerciseCardState createState() => PrevExerciseCardState();
 }
 
-class _PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepAliveClientMixin {
+class PrevExerciseCardState extends State<PrevExerciseCard> with AutomaticKeepAliveClientMixin {
   int index = 0;
   double height = screenHeight * 0.23;
   TotalsData totalData = TotalsData(0, 0, 0.0, 0.0);

--- a/lib/UI/prev_workout/prev_set_widget.dart
+++ b/lib/UI/prev_workout/prev_set_widget.dart
@@ -24,10 +24,10 @@ class PrevSetWidget extends StatefulWidget {
   Function(Exercise, Sets, int) addNewSet;
 
   @override
-  _PrevSetWidgetState createState() => _PrevSetWidgetState();
+  PrevSetWidgetState createState() => PrevSetWidgetState();
 }
 
-class _PrevSetWidgetState extends State<PrevSetWidget>
+class PrevSetWidgetState extends State<PrevSetWidget>
     with AutomaticKeepAliveClientMixin {
   int percent = 0;
   double oneRepMax = 0.0;

--- a/lib/UI/prev_workout/prev_workout_page.dart
+++ b/lib/UI/prev_workout/prev_workout_page.dart
@@ -22,10 +22,10 @@ class PrevWorkoutPage extends StatefulWidget {
   Workout workout;
 
   @override
-  _PrevWorkoutPageState createState() => _PrevWorkoutPageState();
+  PrevWorkoutPageState createState() => PrevWorkoutPageState();
 }
 
-class _PrevWorkoutPageState extends State<PrevWorkoutPage> {
+class PrevWorkoutPageState extends State<PrevWorkoutPage> {
   late WorkoutTotalsWidget workoutTotalsWidget;
   late PrevWorkoutData workoutData;
   String exerciseName = '';

--- a/lib/UI/workout/save_workout_dialog.dart
+++ b/lib/UI/workout/save_workout_dialog.dart
@@ -14,10 +14,10 @@ class SaveWorkoutAlert extends StatefulWidget {
   final Function(String, bool) setWorkout;
   final RaisedGradientButton saveWorkout;
   @override
-  _SaveWorkoutAlertState createState() => _SaveWorkoutAlertState();
+  SaveWorkoutAlertState createState() => SaveWorkoutAlertState();
 }
 
-class _SaveWorkoutAlertState extends State<SaveWorkoutAlert> {
+class SaveWorkoutAlertState extends State<SaveWorkoutAlert> {
   String name = '';
   bool? template;
 

--- a/lib/UI/workout/workout_builder.dart
+++ b/lib/UI/workout/workout_builder.dart
@@ -11,11 +11,11 @@ class WorkoutInformation extends StatefulWidget {
 
   final String id;
   @override
-  _WorkoutInformationState createState() => _WorkoutInformationState();
+  WorkoutInformationState createState() => WorkoutInformationState();
 
 }
 
-class _WorkoutInformationState extends State<WorkoutInformation> {
+class WorkoutInformationState extends State<WorkoutInformation> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<Workout>(

--- a/lib/UI/workout/workout_name_selection_widget.dart
+++ b/lib/UI/workout/workout_name_selection_widget.dart
@@ -14,10 +14,10 @@ class WorkoutTemplateSelectionWidget extends StatefulWidget {
   Function(Workout) setWorkout;
   List workoutList;
   @override
-  _WorkoutNameSelectionWidgetState createState() => _WorkoutNameSelectionWidgetState();
+  WorkoutNameSelectionWidgetState createState() => WorkoutNameSelectionWidgetState();
 }
 
-class _WorkoutNameSelectionWidgetState extends State<WorkoutTemplateSelectionWidget> {
+class WorkoutNameSelectionWidgetState extends State<WorkoutTemplateSelectionWidget> {
   String? dropDownValue;
   Map workoutMap = {};
   @override

--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -21,10 +21,10 @@ class WorkoutPage extends StatefulWidget {
   Workout? workout;
 
   @override
-  _WorkoutPageState createState() => _WorkoutPageState();
+  WorkoutPageState createState() => WorkoutPageState();
 }
 
-class _WorkoutPageState extends State<WorkoutPage> {
+class WorkoutPageState extends State<WorkoutPage> {
   late WorkoutTotalsWidget workoutTotalsWidget;
   late WorkoutData workoutData;
   String exerciseName = '';

--- a/lib/UI/workout/workout_toatals_widget.dart
+++ b/lib/UI/workout/workout_toatals_widget.dart
@@ -8,10 +8,10 @@ class WorkoutTotalsWidget extends StatefulWidget {
   final WorkoutTotals totals;
 
   @override
-  _WorkoutTotalsWidgetState createState() => _WorkoutTotalsWidgetState();
+  WorkoutTotalsWidgetState createState() => WorkoutTotalsWidgetState();
 }
 
-class _WorkoutTotalsWidgetState extends State<WorkoutTotalsWidget> {
+class WorkoutTotalsWidgetState extends State<WorkoutTotalsWidget> {
   @override
   Widget build(BuildContext context) {
     return ThemeProvider(

--- a/lib/src/feature/authentication/widgets/google_signin_button.dart
+++ b/lib/src/feature/authentication/widgets/google_signin_button.dart
@@ -11,10 +11,10 @@ class GoogleSignInButton extends StatefulWidget {
   final FutureOr Function() onPressed;
 
   @override
-  _GoogleSignInButtonState createState() => _GoogleSignInButtonState();
+  GoogleSignInButtonState createState() => GoogleSignInButtonState();
 }
 
-class _GoogleSignInButtonState extends State<GoogleSignInButton> {
+class GoogleSignInButtonState extends State<GoogleSignInButton> {
   bool _isLoading = false;
 
   @override

--- a/lib/src/widgets/gradient_button.dart
+++ b/lib/src/widgets/gradient_button.dart
@@ -22,10 +22,10 @@ class RaisedGradientButton extends StatefulWidget {
   final Gradient? gradient;
 
   @override
-  _RaisedGradientButtonState createState() => _RaisedGradientButtonState();
+  RaisedGradientButtonState createState() => RaisedGradientButtonState();
 }
 
-class _RaisedGradientButtonState extends State<RaisedGradientButton> {
+class RaisedGradientButtonState extends State<RaisedGradientButton> {
   bool _isLoading = false;
 
   @override


### PR DESCRIPTION
### Summary

AVOID using library private types in public APIs.

For the purposes of this lint, a public API is considered to be any top-level or member declaration unless the declaration is library private or contained in a declaration that's library private. The following uses of types are checked:

- the return type of a function or method,
- the type of any parameter of a function or method,
- the bound of a type parameter to any function, method, class, mixin, extension's extended type, or type alias,
- the type of any top level variable or field,
- any type used in the declaration of a type alias (for example typedef F = _Private Function();), or
- any type used in the on clause of an extension or a mixin
