### PR TITLE
feat: start from template button on calendar page

### DIFF
--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -16,9 +16,10 @@ import 'package:exerlog/src/widgets/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 
 class WorkoutPage extends StatefulWidget {
-  WorkoutPage(this.workout, {Key? key}) : super(key: key);
+  WorkoutPage(this.workout, {Key? key, this.isTemplateMode = false}) : super(key: key);
 
   Workout? workout;
+  bool isTemplateMode;
 
   @override
   _WorkoutPageState createState() => _WorkoutPageState();
@@ -136,7 +137,7 @@ class _WorkoutPageState extends State<WorkoutPage> {
                           child: Text('Something went wrong'),
                         );
                       } else {
-                        if (snapshot.data!.isEmpty) {
+                        if (!widget.isTemplateMode) {
                           firstLoad = false;
                           Future.delayed(
                             Duration.zero,

--- a/lib/src/feature/calendar/view/calendar_screen.dart
+++ b/lib/src/feature/calendar/view/calendar_screen.dart
@@ -52,13 +52,28 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 CalendarWidget(),
-                RaisedGradientButton(
-                  width: context.width * .8,
-                  onPressed: _navigateToWorkoutScreen,
-                  child: Text(
-                    Texts.startNewWorkout.toUpperCase(),
-                    style: buttonTextSmall,
-                  ),
+                Column(
+                  children: [
+                    RaisedGradientButton(
+                      width: context.width * .8,
+                      onPressed: _navigateToExerciseScreen,
+                      child: Text(
+                        Texts.startNewWorkout.toUpperCase(),
+                        style: buttonTextSmall,
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 15,
+                    ),
+                    RaisedGradientButton(
+                      width: context.width * .8,
+                      onPressed: _navigateToWorkoutScreen,
+                      child: Text(
+                        Texts.startFromTemplate.toUpperCase(),
+                        style: buttonTextSmall,
+                      ),
+                    ),
+                  ],
                 )
               ],
             ),
@@ -68,10 +83,18 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     );
   }
 
+  void _navigateToExerciseScreen() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (BuildContext context) => WorkoutPage(null),
+      ),
+    );
+  }
+
   void _navigateToWorkoutScreen() {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => WorkoutPage(null),
+        builder: (BuildContext context) => WorkoutPage(null, isTemplateMode: true),
       ),
     );
   }

--- a/lib/src/utils/text_constants.dart
+++ b/lib/src/utils/text_constants.dart
@@ -5,6 +5,7 @@ class Texts {
 
   /// Calendar Screen
   static const startNewWorkout = 'Start new workout';
+  static const startFromTemplate = 'Start from template';
   /// Workout Screen
 
 }


### PR DESCRIPTION
### Summary

Solves issue #28. Added a `Start from template` button on the calendar page alongside the `Start new workout` button. Can now start a new workout even when templates exists.

### Other Information

N/A
