### PR TITLE
fix: black screen we pop workout_page

### DIFF
--- a/lib/UI/workout/workout_page.dart
+++ b/lib/UI/workout/workout_page.dart
@@ -91,10 +91,10 @@ class _WorkoutPageState extends State<WorkoutPage> {
           appBar: AppBar(
             backgroundColor: theme.colorTheme.backgroundColorVariation,
             leading: BackButton(
-              onPressed: Navigator.of(context).pop,
+              onPressed: Navigator.of(context).maybePop,
               color: theme.colorTheme.primaryColor,
             ),
-            actions: <Widget> [
+            actions: <Widget>[
               Container(
                 margin: const EdgeInsets.only(right: 5),
                 height: 30,


### PR DESCRIPTION
… tried to pop it, it will pop to black screen

### Summary

**when sign up is success and push a workou_page then if the user tried to pop it, it  will pop to black screen**

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes.

Thanks for contributing! -->
